### PR TITLE
Use NamedTuple for important direction

### DIFF
--- a/src/inputs/jointdistribution.jl
+++ b/src/inputs/jointdistribution.jl
@@ -25,7 +25,7 @@ function sample(jd::JointDistribution, n::Integer=1)
 end
 
 function to_physical_space!(jd::JointDistribution, x::DataFrame)
-    correlated_cdf = to_copula_space(jd.copula, Matrix(x[:, names(jd)]))
+    correlated_cdf = to_copula_space(jd.copula, convert(Matrix, x[:, names(jd)]))
     for (i, rv) in enumerate(jd.marginals)
         x[!, rv.name] = quantile.(rv.dist, correlated_cdf[:, i])
     end
@@ -36,7 +36,7 @@ function to_standard_normal_space!(jd::JointDistribution, x::DataFrame)
     for rv in jd.marginals
         x[!, rv.name] = cdf.(rv.dist, x[:, rv.name])
     end
-    uncorrelated_stdnorm = to_standard_normal_space(jd.copula, Matrix(x[:, names(jd)]))
+    uncorrelated_stdnorm = to_standard_normal_space(jd.copula, convert(Matrix, x[:, names(jd)]))
     for (i, rv) in enumerate(jd.marginals)
         x[!, rv.name] = uncorrelated_stdnorm[:, i]
     end

--- a/src/sensitivity/gradient.jl
+++ b/src/sensitivity/gradient.jl
@@ -23,7 +23,7 @@ function gradient(
 
     g = grad(forward_fdm(2, 1), f, reference)[1]
 
-    return DataFrame(random_names .=> eachcol(g))
+    return (; zip(random_names, g)...)
 end
 
 function gradient_in_standard_normal_space(
@@ -50,5 +50,5 @@ function gradient_in_standard_normal_space(
 
     g = grad(forward_fdm(2, 1), f, reference)[1]
 
-    return DataFrame(random_names .=> eachcol(g))
+    return (; zip(random_names, g)...)
 end

--- a/src/simulations/montecarlo.jl
+++ b/src/simulations/montecarlo.jl
@@ -13,8 +13,6 @@ struct HaltonSampling <: AbstractMonteCarloSampling
     HaltonSampling(n) = n > 0 ? new(n) : error("n must be greater than zero")
 end
 
-const Φ = Normal()
-
 function sample(inputs::Array{<:UQInput}, sim::MonteCarlo)
     sample(inputs, sim.n)
 end
@@ -33,7 +31,7 @@ function sample(inputs::Array{<:UQInput}, sim::SobolSampling)
 
     u = hcat([next!(s) for i = 1:sim.n]...) |> transpose
 
-    samples = quantile.(Φ, u)
+    samples = quantile.(Normal(), u)
     samples = DataFrame(names(random_inputs) .=> eachcol(samples))
 
     if !isempty(deterministic_inputs)

--- a/test/sensitivity/gradient.jl
+++ b/test/sensitivity/gradient.jl
@@ -10,8 +10,8 @@
 
         g = gradient([model], [p, x, y], DataFrame(p = 2.0, x = 2.0, y = 1.0), :f)
 
-        @test isapprox(g.x[1], 8.0, rtol = 0.001)
-        @test isapprox(g.y[1], -2.0, rtol = 0.001)
+        @test isapprox(g.x, 8.0, rtol = 0.001)
+        @test isapprox(g.y, -2.0, rtol = 0.001)
 
     end
 end


### PR DESCRIPTION
Using a DataFrame for the important direction did not make a lot of sense, since it is always only a single row. A NamedTuple is much simpler while still having the benefit of keeping the symbols and values together.