### PR TITLE
Drop dependency on HaltonSequence

### DIFF
--- a/src/simulations/montecarlo.jl
+++ b/src/simulations/montecarlo.jl
@@ -47,15 +47,23 @@ function qmc_samples(sim::SobolSampling, rvs::Integer)
 end
 
 function qmc_samples(sim::HaltonSampling, rvs::Integer)
-    h = HaltonPoint(rvs; length=sim.n)
+    prime = ones(rvs*rvs)
+    prime[1] = 0 
+    pl = 2
+    kl = rvs
+    coprimes = zeros(rvs)
+    while kl>0
+     if prime[pl]==1
+         for i in (pl*pl):pl:(rvs*rvs)
+             prime[i] = 0
+         end
+         kl-=1
+         coprimes[rvs-kl] = pl
+      end
+     pl+=1
+     end
 
-    u = zeros(sim.n, rvs)
-
-    for (i, hp) in enumerate(h)
-        u[i, :] = hp
-    end
-
-    return u
+    return transpose(QuasiMonteCarlo.sample(sim.n, zeros(rvs), ones(rvs), LowDiscrepancySample(coprimes)))
 end
 
 function qmc_samples(sim::LatinHypercubeSampling, rvs::Integer)


### PR DESCRIPTION
The dependency on the HaltonSequence is dropped. The code uses LowDiscrepancySample to calculate sample using HaltonSampling. The code has been modified to calculate the prime number required for HaltonSampling, the algorithm of the code is based on the idea of Sieve of Eratosthenes.