### PR TITLE
Split modified metropolis hastings  samples and evaluate cov in subset simulation

### DIFF
--- a/demo/reliability/cantilever.jl
+++ b/demo/reliability/cantilever.jl
@@ -57,7 +57,7 @@ println(
 
 subset = UncertaintyQuantification.SubSetSimulation(2000, 0.1, 10, Uniform(-0.5, 0.5))
 
-subset_pf, subset_samples, cov_pf = probability_of_failure(
+subset_pf, subset_cov, subset_samples= probability_of_failure(
     [inertia, displacement], df -> max_displacement .- df.w, inputs, subset
 )
 

--- a/demo/reliability/cantilever.jl
+++ b/demo/reliability/cantilever.jl
@@ -57,7 +57,7 @@ println(
 
 subset = UncertaintyQuantification.SubSetSimulation(2000, 0.1, 10, Uniform(-0.5, 0.5))
 
-subset_pf, subset_samples = probability_of_failure(
+subset_pf, subset_samples, cov_pf = probability_of_failure(
     [inertia, displacement], df -> max_displacement .- df.w, inputs, subset
 )
 

--- a/src/simulations/subset.jl
+++ b/src/simulations/subset.jl
@@ -28,16 +28,11 @@ function sample(inputs::Array{<:UQInput}, sim::SubSetSimulation)
     if !isempty(deterministic_inputs)
         samples = hcat(samples, sample(deterministic_inputs, sim.n))
     end
-
     return samples
 end
 
-function probability_of_failure(
-    models::Union{Array{<:UQModel},UQModel},
-    performancefunction::Function,
-    inputs::Union{Array{T},T} where {T<:UQInput},
-    sim::SubSetSimulation,
-)
+function probability_of_failure(models::Union{Array{<:UQModel},UQModel},performancefunction::Function,inputs::Union{Array{T},T} where {T<:UQInput},sim::SubSetSimulation)
+
     random_inputs = filter(i -> isa(i, RandomUQInput), inputs)
     rvs = names(random_inputs)
 
@@ -48,11 +43,11 @@ function probability_of_failure(
     performance = [performancefunction(samples[end])]
 
     number_of_chains = Int64(max(1, ceil(sim.n * sim.target)))
-    samples_per_chain = floor(sim.n / number_of_chains)
+    samples_per_chain = Int64(floor(sim.n / number_of_chains))
 
     threshold = zeros(sim.levels, 1)
     pf = ones(sim.levels, 1)
-    CoV = zeros(sim.levels, 1)
+    cov = zeros(sim.levels, 1)
 
     for i in 1:(sim.levels)
         sorted_performance = sort(performance[end])
@@ -67,7 +62,7 @@ function probability_of_failure(
 
         ## Std MC covariance
         if i == 1
-            CoV[i] = sqrt((pf[i] - pf[i]^2) / (sim.n * pf[i]))
+            cov[i] = sqrt((pf[i] - pf[i]^2) / sim.n) / pf[i]
         end
 
         nextlevelsamples = [samples[end][sorted_indices[1:number_of_chains], :]]
@@ -79,9 +74,7 @@ function probability_of_failure(
 
             to_standard_normal_space!(inputs, chainsamples)
 
-            chainsamples[:, rvs], α_accept = candidatesamples(
-                Matrix{Float64}(chainsamples[:, rvs]), sim.proposal
-            )
+            chainsamples[:, rvs], α_accept = candidatesamples(Matrix{Float64}(chainsamples[:, rvs]), sim.proposal)
 
             to_physical_space!(inputs, chainsamples)
 
@@ -95,9 +88,7 @@ function probability_of_failure(
                 performance_accept = to_evalperformance .< threshold[i]
                 chainsamples = copy(nextlevelsamples[end])
                 chainperformance = copy(nextlevelperformance[end])
-                chainsamples[α_accept_indices[performance_accept], :] = to_eval[
-                    performance_accept, :
-                ]
+                chainsamples[α_accept_indices[performance_accept], :] = to_eval[performance_accept, :]
                 chainperformance[α_accept_indices[performance_accept]] = to_evalperformance[performance_accept]
             else
                 chainsamples = copy(nextlevelsamples[end])
@@ -120,30 +111,8 @@ function probability_of_failure(
         push!(performance, nextlevelperformance)
 
         if i > 1
-            Mindicator_i = transpose(Mindicator_i .< max(threshold[i], 0))
-            ## Compute CoV of the indicator function across different chainsamples
-            # Eq 29
-            Ri = zeros(1, Int(samples_per_chain))
-            for k in 1:Int(samples_per_chain)
-                for j in 1:number_of_chains
-                    for l in 1:(Int(samples_per_chain - (k - 1)))
-                        Ri[k] = Ri[k] + Mindicator_i[l, j] * Mindicator_i[l + k - 1, j]
-                    end
-                end
-                Ri[k] = Ri[k] / (sim.n - (k - 1) * number_of_chains) - pf[i]^2
-            end
-            # Eq 25
-            ρ = Ri / Ri[1]
-            # Eq 27
-            γ_i = 0
-            for k in 1:(Int(samples_per_chain) - 1)
-                γ_i = γ_i + (1 - k * n_markovChain / sim.n) * ρ[k]
-            end
-            γ_i = 2 * γ_i
-            #Eq 28
-            CoV[i] = sqrt((1 - pf[i]) / (pf[i] * sim.n) * (1 + γ_i))
+            cov[i] = chaincovi(nextlevelperformance, number_of_chains, samples_per_chain, threshold[i], pf[i], sim.n)
         end
-
         ## Break the loop
         if threshold[i] <= 0 || i == sim.levels
             break
@@ -154,12 +123,13 @@ function probability_of_failure(
     for i in eachindex(samples)
         samples[i][!, :level] .= i
     end
-    # merge (vcat) all samples
+    # merge (vcat) all saÊmples
     samples = reduce(vcat, samples)
 
     pf = prod(pf)
+    cov_pf = sqrt(sum((cov .^ 2)))
 
-    return pf, samples
+    return pf, samples, cov_pf
 end
 
 function candidatesamples(θ::AbstractMatrix, proposal::Sampleable{Univariate})
@@ -174,3 +144,33 @@ function candidatesamples(θ::AbstractMatrix, proposal::Sampleable{Univariate})
 
     return θ, accept
 end
+
+function chaincovi(nextlevelperformance::Vector{Float64}, number_of_chains::Int64, samples_per_chain::Int64, threshold::Float64, pf::Float64, sim_n::Int64)
+    # Building indicator Matrix (Boolean)
+    indicator = reshape(nextlevelperformance, number_of_chains, samples_per_chain)
+    indicator = transpose(indicator .< max(threshold, 0))
+    ```Estimation of small failure probabilities in high dimensions by subset simulation
+    ```
+    # Eq 29 - covariance vecotr between indicator(l) and indicator(l+k) -> ri
+    ri = zeros(1, samples_per_chain)
+    for k in 1:samples_per_chain
+        for j in 1:number_of_chains
+            for l in 1:(Int(samples_per_chain - (k - 1)))
+                ri[k] = ri[k] + indicator[l, j] * indicator[l + k - 1, j]
+            end
+        end
+        ri[k] = ri[k] / (sim_n - (k - 1) * number_of_chains) - pf^2
+    end
+    # Eq 25 - correlation coefficient vector ρ
+    ρ = ri / ri[1]
+    # Eq 27 - γ_i Bernoulli coefficient 
+    γ_i = 0
+    for k in 1:(samples_per_chain - 1)
+        γ_i = γ_i + (1 - k * number_of_chains / sim_n) * ρ[k]
+    end
+    γ_i = 2 * γ_i
+    #Eq 28 - i-level coefficient of variation (Metropolis Markov Chain)
+    cov_i = sqrt((1 - pf) / (pf * sim_n) * (1 + γ_i))
+    return cov_i
+end
+


### PR DESCRIPTION
The split is made in order to avoid ```evaluate!``` calls when ```candidatesamples``` generate one (or more) alpha-rejected sample.