### PR TITLE
Automatic deletion of external model files

### DIFF
--- a/src/models/externalmodel.jl
+++ b/src/models/externalmodel.jl
@@ -48,11 +48,11 @@ function evaluate!(m::ExternalModel, df::DataFrame)
 
         run(m.solver, path)
 
-        sim_result = map(e -> e.f(path), m.extractors)
+        result = map(e -> e.f(path), m.extractors)
         if m.cleanup
             rm(path, recursive=true)
         end
-        return sim_result
+        return result
     end
 
     results = transpose(hcat(results...))

--- a/src/models/externalmodel.jl
+++ b/src/models/externalmodel.jl
@@ -1,11 +1,25 @@
 struct ExternalModel <: UQModel
     sourcedir::String
-    sources::Array{String,1}
-    extras::Array{String,1}
+    sources::Vector{String}
+    extras::Vector{String}
     formats::Dict{Symbol,FormatSpec}
     workdir::String
     extractors::Array{Extractor,1}
     solver::Solver
+    cleanup::Bool
+
+    function ExternalModel(    
+        sourcedir::String,
+        sources::Vector{String},
+        extras::Vector{String},
+        formats::Dict{Symbol,FormatSpec},
+        workdir::String,
+        extractors::Array{Extractor,1},
+        solver::Solver,
+        cleanup::Bool=false
+    )
+    return new(sourcedir, sources, extras, formats, workdir, extractors, solver, cleanup)       
+    end
 end
 
 function evaluate!(m::ExternalModel, df::DataFrame)
@@ -34,7 +48,11 @@ function evaluate!(m::ExternalModel, df::DataFrame)
 
         run(m.solver, path)
 
-        return map(e -> e.f(path), m.extractors)
+        sim_result = map(e -> e.f(path), m.extractors)
+        if m.cleanup
+            rm(path, recursive=true)
+        end
+        return sim_result
     end
 
     results = transpose(hcat(results...))

--- a/src/models/externalmodel.jl
+++ b/src/models/externalmodel.jl
@@ -4,7 +4,7 @@ struct ExternalModel <: UQModel
     extras::Vector{String}
     formats::Dict{Symbol,FormatSpec}
     workdir::String
-    extractors::Array{Extractor,1}
+    extractors::Vector{Extractor}
     solver::Solver
     cleanup::Bool
 
@@ -14,7 +14,7 @@ struct ExternalModel <: UQModel
         extras::Vector{String},
         formats::Dict{Symbol,FormatSpec},
         workdir::String,
-        extractors::Array{Extractor,1},
+        extractors::Vector{Extractor},
         solver::Solver,
         cleanup::Bool=false
     )

--- a/test/models/externalmodel.jl
+++ b/test/models/externalmodel.jl
@@ -38,16 +38,15 @@
             sourcefiles,
             extrafiles,
             numberformats,
-            tempname(), 
+            tempname(),
             [r],
             opensees,
             false,
         )
         evaluate!(ext, df)
         @test length(readdir(readdir(ext.workdir; join=true)[1])) != 0
+        @test isapprox(df.r, sqrt.(df.x .^ 2 + df.y .^ 2))
     end
-    @test isapprox(df.r, sqrt.(df.x .^ 2 + df.y .^ 2))
-
 
     @testset "Cleanup" begin
         ext = ExternalModel(
@@ -62,7 +61,6 @@
         )
         evaluate!(ext, df)
         @test length(readdir(readdir(ext.workdir; join=true)[1])) == 0
+        @test isapprox(df.r, sqrt.(df.x .^ 2 + df.y .^ 2))
     end
-
-    @test isapprox(df.r, sqrt.(df.x .^ 2 + df.y .^ 2))
 end

--- a/test/models/externalmodel.jl
+++ b/test/models/externalmodel.jl
@@ -33,13 +33,12 @@
     df = sample([x, y], 1)
 
     @testset "No Cleanup" begin
-        workdir_nocleanup = tempdir()
         ext = ExternalModel(
             sourcedir,
             sourcefiles,
             extrafiles,
             numberformats,
-            workdir_nocleanup,
+            tempname(), 
             [r],
             opensees,
             false,
@@ -47,15 +46,16 @@
         evaluate!(ext, df)
         @test length(readdir(readdir(ext.workdir; join=true)[1])) != 0
     end
+    @test isapprox(df.r, sqrt.(df.x .^ 2 + df.y .^ 2))
+
 
     @testset "Cleanup" begin
-        workdir_cleanup = tempname()
         ext = ExternalModel(
             sourcedir,
             sourcefiles,
             extrafiles,
             numberformats,
-            workdir_cleanup,
+            tempname(),
             [r],
             opensees,
             true,

--- a/test/models/externalmodel.jl
+++ b/test/models/externalmodel.jl
@@ -1,11 +1,11 @@
 @testset "ExternalModel" begin
     sourcedir = tempdir()
     sourcefiles = ["in.txt"]
-    extrafiles = []
+    extrafiles = String[]
 
     numberformats = Dict(:x => FormatSpec(".8e"), :* => FormatSpec(".8e"))
 
-    workdir = joinpath(tempdir(), "external-model-test")
+    workdir = map(i->(joinpath(tempdir(), "external-model-test-$(i)"), i), [true, false])
 
     r = Extractor(
         base -> begin
@@ -24,9 +24,9 @@
 
     opensees = Solver(binary, "", "in.txt")
 
-    ext = ExternalModel(
-        sourcedir, sourcefiles, extrafiles, numberformats, workdir, [r], opensees
-    )
+    ext = map(ii->ExternalModel(
+        sourcedir, sourcefiles, extrafiles, numberformats, ii[1], [r], opensees, ii[2]
+    ), [workdir[1], workdir[2]])
 
     open(joinpath(sourcedir, "in.txt"), "w") do input
         println(input, "{{{ :x }}}")
@@ -38,7 +38,14 @@
 
     df = sample([x, y], 1)
 
-    evaluate!(ext, df)
-
+    for model in ext
+        evaluate!(model, df)
+        if model.cleanup
+            @test length(readdir(readdir(model.workdir, join=true)[1])) == 0
+        else
+            @test length(readdir(readdir(model.workdir, join=true)[1])) != 0
+        end
+    end
+ 
     @test isapprox(df.r, sqrt.(df.x .^ 2 + df.y .^ 2))
 end


### PR DESCRIPTION
In order to not fill the hard disk during long simulation with external solvers, a _cleanup_ flag has been added to the struct _ExternalModel_. Its default value is set to _false_.
2 tests have been added in order to verify the functioning of the _cleanup_ flag.