### PR TITLE
Add ParallelModel

### DIFF
--- a/src/UncertaintyQuantification.jl
+++ b/src/UncertaintyQuantification.jl
@@ -62,6 +62,7 @@ export LegendreBasis
 export LineSampling
 export Model
 export MonteCarlo
+export ParallelModel
 export Parameter
 export PolynomialChaosBasis
 export PolynomialChaosExpansion

--- a/src/models/model.jl
+++ b/src/models/model.jl
@@ -3,18 +3,32 @@ struct Model <: UQModel
     name::Symbol
 end
 
-function (obj::Model)(df::DataFrame)
-    return obj.func(df)
+struct ParallelModel <: UQModel
+    func::Function
+    name::Symbol
 end
 
-function evaluate!(models::Array{T,1} where {T<:UQModel}, df::DataFrame)
-    for m in models
-        evaluate!(m, df)
-    end
-    return nothing
+function (m::Model)(df::DataFrame)
+    return m.func(df)
+end
+
+function (m::ParallelModel)(df::DataFrame)
+    return pmap(m.func, eachrow(df))
 end
 
 function evaluate!(m::Model, df::DataFrame)
     df[!, m.name] = m.func(df)
+    return nothing
+end
+
+function evaluate!(m::ParallelModel, df::DataFrame)
+    df[!, m.name] = pmap(m.func, eachrow(df))
+    return nothing
+end
+
+function evaluate!(models::Vector{T} where {T<:UQModel}, df::DataFrame)
+    for m in models
+        evaluate!(m, df)
+    end
     return nothing
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 QuasiMonteCarlo = "8a4e6c94-4038-4cdc-81c3-7e6ffdb2a71b"

--- a/test/models/model.jl
+++ b/test/models/model.jl
@@ -5,6 +5,26 @@
     @test isa(model, Model)
 
     evaluate!(model, input)
-    @test input == DataFrame(; a=1, b=2, c=5)
+    @test input.c == [5]
     @test model(input) == [5]
+end
+
+@testset "ParallelModel" begin
+    procs = addprocs(2)
+
+    @everywhere using UncertaintyQuantification
+
+    input = DataFrame(; a=rand(6), b=rand(6))
+
+    model = ParallelModel(df -> df.a + 2 * df.b, :c)
+
+    @test isa(model, ParallelModel)
+
+    try
+        evaluate!(model, input)
+        @test input.c == input.a .+ 2 .* input.b
+        @test model(input) == input.a .+ 2 .* input.b
+    finally
+        rmprocs(procs)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using DataFrames
+using Distributed
 using Formatting
 using InteractiveUtils
 using QuasiMonteCarlo


### PR DESCRIPTION
The ParallelModel evaluates the rows of a DataFrame using a pmap. It's necessary to run `"everywhere using UncertaintyQuantification" first to load the package on all available workers. Will still work without workers by running in serial.

Closes #95.