### PR TITLE
Add convenience methods for rvs

### DIFF
--- a/src/UncertaintyQuantification.jl
+++ b/src/UncertaintyQuantification.jl
@@ -22,6 +22,7 @@ using Symbolics
 
 import Base: rand, names, copy, run, length
 import Statistics: mean, var
+import Distributions: logpdf, pdf, cdf, quantile, minimum, maximum, insupport, mean, var
 
 abstract type UQType end
 

--- a/src/inputs/inputs.jl
+++ b/src/inputs/inputs.jl
@@ -42,4 +42,4 @@ function count_rvs(inputs::Array{<:UQInput})
     return mapreduce(dimensions, +, random_inputs)
 end
 
-mean(inputs::Array{<:UQInput}) = mapreduce(mean, hcat, inputs)
+mean(inputs::Array{<:UQInput}) = mapreduce(mean, vcat, inputs)

--- a/src/inputs/jointdistribution.jl
+++ b/src/inputs/jointdistribution.jl
@@ -1,8 +1,8 @@
 struct JointDistribution <: RandomUQInput
-    marginals::Array{RandomVariable}
+    marginals::Vector{RandomVariable}
     copula::Copula
 
-    function JointDistribution(marginals::Array{RandomVariable}, copula::Copula)
+    function JointDistribution(marginals::Vector{RandomVariable}, copula::Copula)
         length(marginals) == dimensions(copula) ||
             error("Dimension mismatch between copula and marginals")
 
@@ -45,6 +45,6 @@ end
 
 names(jd::JointDistribution) = vec(map(x -> x.name, jd.marginals))
 
-mean(jd::JointDistribution) = mean(jd.marginals)
+mean(jd::JointDistribution) = mean.(jd.marginals)
 
 dimensions(jd::JointDistribution) = dimensions(jd.copula)

--- a/src/inputs/parameter.jl
+++ b/src/inputs/parameter.jl
@@ -21,4 +21,4 @@ end
 to_standard_normal_space!(p::Parameter, x::DataFrame) = nothing
 to_physical_space!(p::Parameter, x::DataFrame) = nothing
 
-mean(p::Parameter) = DataFrame(p.name => p.value)
+mean(p::Parameter) = p.value

--- a/src/inputs/randomvariable.jl
+++ b/src/inputs/randomvariable.jl
@@ -1,5 +1,5 @@
 """
-	RandomVariable(dist::Sampleable{Univariate}, name::Symbol)
+	RandomVariable(dist::UnivariateDistribution, name::Symbol)
 
 Defines a random variable, with a univariate distribution from Distributions.jl and a name.
 
@@ -14,7 +14,7 @@ RandomVariable(Exponential{Float64}(θ=1.0), :x)
 ```
 """
 struct RandomVariable <: RandomUQInput
-    dist::Sampleable{Univariate}
+    dist::UnivariateDistribution
     name::Symbol
 end
 
@@ -43,7 +43,14 @@ function to_standard_normal_space!(rv::RandomVariable, x::DataFrame)
     return nothing
 end
 
-mean(rv::RandomVariable) = DataFrame(rv.name => Distributions.mean(rv.dist))
-mean(rvs::Array{RandomVariable}) = mapreduce(mean, hcat, rvs)
-
 dimensions(rv::RandomVariable) = 1
+
+logpdf(rv::RandomVariable, x::Real) = logpdf(rv.dist, x)
+pdf(rv::RandomVariable, x::Real) = pdf(rv.dist, x)
+cdf(rv::RandomVariable, x::Real) = cdf(rv.dist, x)
+quantile(rv::RandomVariable, q::Real) = quantile(rv.dist, q)
+minimum(rv::RandomVariable) = minimum(rv.dist)
+maximum(rv::RandomVariable) = maximum(rv.dist)
+insupport(rv::RandomVariable, x::Real) = insupport(rv.dist, x)
+mean(rv::RandomVariable) = mean(rv.dist)
+var(rv::RandomVariable) = var(rv.dist)

--- a/src/reliability/probabilityoffailure.jl
+++ b/src/reliability/probabilityoffailure.jl
@@ -26,7 +26,7 @@ function probability_of_failure(
         sim.direction = gradient_in_standard_normal_space(
             [models..., Model(x -> -1 * performance(x), :performance)],
             inputs,
-            mean(inputs),
+            DataFrame(names(inputs) .=> mean(inputs)),
             :performance,
         )
     end

--- a/src/simulations/subset.jl
+++ b/src/simulations/subset.jl
@@ -1,7 +1,7 @@
 abstract type AbstractSubSetSimulation end
 
 """
-    SubSetSimulation(n::Integer, target::Float64, levels::Integer, proposal::Sampleable{Univariate})
+    SubSetSimulation(n::Integer, target::Float64, levels::Integer, proposal::UnivariateDistribution)
 
 Defines the properties of a Subset simulation where `n` is the number of initial samples,
 `target` is the target probability of failure at each level, `levels` is the maximum number
@@ -22,10 +22,10 @@ struct SubSetSimulation <: AbstractSubSetSimulation
     n::Integer
     target::Float64
     levels::Integer
-    proposal::Sampleable{Univariate}
+    proposal::UnivariateDistribution
 
     function SubSetSimulation(
-        n::Integer, target::Float64, levels::Integer, proposal::Sampleable{Univariate}
+        n::Integer, target::Float64, levels::Integer, proposal::UnivariateDistribution
     )
         skewness(proposal) != 0.0 && error("proposal must be a symmetric distribution")
         mean(proposal) != median(proposal) &&
@@ -209,6 +209,9 @@ function nextlevelsamples(
             chainsamples[α_accept_indices, :] = new_samples
             chainperformance[α_accept_indices] = new_samplesperformance
         end
+
+        # chainsamples = chainsamples[α_accept_indices, :]
+        # chainperformance = chainperformance[α_accept_indices]
 
         push!(nextlevelsamples, chainsamples)
         push!(nextlevelperformance, chainperformance)

--- a/test/inputs/inputs.jl
+++ b/test/inputs/inputs.jl
@@ -17,11 +17,11 @@ inputs = [pi, jd, z]
 
     @testset "mean" begin
         means = mean(inputs)
-        @test size(means) == (1, 4)
-        @test means.π[1] == 3.14
-        @test means.x[1] == 0
-        @test means.y[1] == 1
-        @test means.z[1] == 0
+        @test size(means) == (4,)
+        @test means[1] == 3.14
+        @test means[2] == 0
+        @test means[3] == 1
+        @test means[4] == 0
     end
 
     @testset "names" begin

--- a/test/inputs/jointdistribution.jl
+++ b/test/inputs/jointdistribution.jl
@@ -3,7 +3,7 @@ using Random, DataFrames
 rv1 = RandomVariable(Exponential(1), :x)
 rv2 = RandomVariable(Exponential(1 / 2), :y)
 
-marginals = [rv1 rv2]
+marginals = [rv1, rv2]
 copula = GaussianCopula([1 0.8; 0.8 1])
 
 @testset "JointDistribution" begin
@@ -32,7 +32,7 @@ copula = GaussianCopula([1 0.8; 0.8 1])
 
     @testset "mean" begin
         jd = JointDistribution(marginals, copula)
-        @test mean(jd) == DataFrame(:x => 1.0, :y => 0.5)
+        @test mean(jd) == [1.0, 0.5]
     end
 
     @testset "to_standard_normal_space" begin

--- a/test/inputs/parameter.jl
+++ b/test/inputs/parameter.jl
@@ -8,7 +8,7 @@
 
     @test sample(π, 5) == x
 
-    @test mean(π) == DataFrame(; π=3.14)
+    @test mean(π) == 3.14
 
     to_standard_normal_space!(π, x)
     @test x == DataFrame(; π=[3.14, 3.14, 3.14, 3.14, 3.14])

--- a/test/inputs/randomvariable.jl
+++ b/test/inputs/randomvariable.jl
@@ -10,4 +10,30 @@
 
     @test size(sample(x)) == (1, 1)
     @test size(sample(x, 10)) == (10, 1)
+
+    @test logpdf(x, -1.0) == logpdf(x.dist, -1.0)
+    @test logpdf(x, 1.0) == logpdf(x.dist, 1.0)
+    @test logpdf(x, 0.0) == logpdf(x.dist, 0.0)
+
+    @test pdf(x, -1.0) == pdf(x.dist, -1.0)
+    @test pdf(x, 1.0) == pdf(x.dist, 1.0)
+    @test pdf(x, 0.0) == pdf(x.dist, 0.0)
+
+    @test cdf(x, -1.0) == cdf(x.dist, -1.0)
+    @test cdf(x, 1.0) == cdf(x.dist, 1.0)
+    @test cdf(x, 0.0) == cdf(x.dist, 0.0)
+
+    @test quantile(x, 0.0) == quantile(x.dist, 0.0)
+    @test quantile(x, 0.5) == quantile(x.dist, 0.5)
+    @test quantile(x, 1.0) == quantile(x.dist, 1.0)
+
+    @test minimum(x) == minimum(x.dist)
+    @test maximum(x) == maximum(x.dist)
+    @test mean(x) == mean(x.dist)
+    @test var(x) == var(x.dist)
+
+    y = RandomVariable(Uniform(), :y)
+    @test insupport(x, -1) == insupport(x.dist, -1)
+    @test insupport(x, 0) == insupport(x.dist, 0)
+    @test insupport(x, 1) == insupport(x.dist, 1)
 end


### PR DESCRIPTION
Also changes mean to return a Vector instead of a `DataFrame` for a `Vector` of inputs or `JointDistribution`. All occurrences of `Sampleable{Univariate}` have been changed to `UnivariateDistribution`.