### PR TITLE
Replace Symbolics with recurrence formulas

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,6 @@ QuasiMonteCarlo = "8a4e6c94-4038-4cdc-81c3-7e6ffdb2a71b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
 Bootstrap = "2.2"
@@ -37,5 +36,4 @@ Mustache = "1.0"
 Primes = "0.5"
 QuasiMonteCarlo = "0.2.10"
 Reexport = "0.2, 1.0"
-Symbolics = "4, 5"
 julia = "1.6, 1.7, 1.8"

--- a/src/UncertaintyQuantification.jl
+++ b/src/UncertaintyQuantification.jl
@@ -15,7 +15,6 @@ using Primes
 using QuasiMonteCarlo
 using Random
 using Reexport
-using Symbolics
 
 @reexport using Distributions
 

--- a/test/models/pce/pcebases.jl
+++ b/test/models/pce/pcebases.jl
@@ -2,7 +2,7 @@
     @testset "LegendreBasis" begin
         x = range(-1, 1; length=10)
 
-        Ψ = LegendreBasis(4, false)
+        Ψ = LegendreBasis(false)
 
         @test evaluate(Ψ, x, 0) == ones(10)
         @test evaluate(Ψ, x, 1) == x
@@ -10,7 +10,7 @@
         @test evaluate(Ψ, x, 3) ≈ (1 / 2) * (5x .^ 3 .- 3x)
         @test evaluate(Ψ, x, 4) ≈ (1 / 8) * (35x .^ 4 .- 30x .^ 2 .+ 3)
 
-        Ψ = LegendreBasis(4, true)
+        Ψ = LegendreBasis()
 
         @test evaluate(Ψ, x, 0) == ones(10)
         @test evaluate(Ψ, x, 1) == x .* sqrt(3)

--- a/test/models/pce/pcebases.jl
+++ b/test/models/pce/pcebases.jl
@@ -38,7 +38,7 @@
     @testset "HermiteBasis" begin
         x = range(-3, 3; length=10)
 
-        Ψ = HermiteBasis(4, false)
+        Ψ = HermiteBasis(false)
 
         @test evaluate(Ψ, x, 0) == ones(10)
         @test evaluate(Ψ, x, 1) == x
@@ -46,7 +46,7 @@
         @test evaluate(Ψ, x, 3) ≈ x .^ 3 .- 3x
         @test evaluate(Ψ, x, 4) ≈ x .^ 4 .- 6x .^ 2 .+ 3
 
-        Ψ = HermiteBasis(4, true)
+        Ψ = HermiteBasis()
 
         @test evaluate(Ψ, x, 0) == ones(10)
         @test evaluate(Ψ, x, 1) == x

--- a/test/models/pce/polynomialchaosexpansion.jl
+++ b/test/models/pce/polynomialchaosexpansion.jl
@@ -6,7 +6,7 @@
     end, :y)
 
     p = 8
-    Ψ = PolynomialChaosBasis([LegendreBasis(p), HermiteBasis(p), LegendreBasis(p)], p)
+    Ψ = PolynomialChaosBasis([LegendreBasis(p), HermiteBasis(), LegendreBasis(p)], p)
 
     @testset "LeastSquares" begin
         ls = LeastSquares(SobolSampling(1000))

--- a/test/models/pce/polynomialchaosexpansion.jl
+++ b/test/models/pce/polynomialchaosexpansion.jl
@@ -6,7 +6,7 @@
     end, :y)
 
     p = 8
-    Ψ = PolynomialChaosBasis([LegendreBasis(p), HermiteBasis(), LegendreBasis(p)], p)
+    Ψ = PolynomialChaosBasis([LegendreBasis(), HermiteBasis(), LegendreBasis()], p)
 
     @testset "LeastSquares" begin
         ls = LeastSquares(SobolSampling(1000))

--- a/test/sensitivity/sobolindices.jl
+++ b/test/sensitivity/sobolindices.jl
@@ -78,7 +78,8 @@
 
     @testset "Polynomial Chaos Expansion" begin
         p = 6
-        Ψ = PolynomialChaosBasis(LegendreBasis.([p, p, p]), p)
+        basis = LegendreBasis()
+        Ψ = PolynomialChaosBasis([basis, basis, basis], p)
 
         gq = GaussQuadrature()
         pce, _ = polynomialchaos(x, ishigami1, Ψ, :f1, gq)


### PR DESCRIPTION
Turns out this is much faster and cleaner than using `Symbolics` to build functions. As a benefit the dependency (which is quite heavy) can be dropped altogether.

The constructor for the pce bases changed slighty as a result. The degree doesn't need to be included any more.