### PR TITLE
Improve mappings between physcial and standard normal space

### DIFF
--- a/src/inputs/randomvariable.jl
+++ b/src/inputs/randomvariable.jl
@@ -25,8 +25,6 @@ Generates n samples from a random variable. Returns a DataFrame.
 
 # Examples
 
-
-
 See also: [`RandomVariable`](@ref)
 """
 function sample(rv::RandomVariable, n::Integer=1)
@@ -34,13 +32,53 @@ function sample(rv::RandomVariable, n::Integer=1)
 end
 
 function to_physical_space!(rv::RandomVariable, x::DataFrame)
-    x[!, rv.name] = quantile.(rv.dist, cdf.(Normal(), x[:, rv.name]))
+    x[!, rv.name] = _to_physical_space(rv.dist, x[:, rv.name])
     return nothing
 end
 
+function _to_physical_space(d::UnivariateDistribution, x::Vector)
+    return quantile.(d, cdf.(Normal(), x))
+end
+
+function _to_physical_space(d::Normal, x::Vector)
+    if d.μ == 0.0 && d.σ == 1.0
+        return x
+    else
+        return x .* d.σ .+ d.μ
+    end
+end
+
+function _to_physical_space(d::LogNormal, x::Vector)
+    return exp.(x .* d.σ .+ d.μ)
+end
+
+function _to_physical_space(d::Uniform, x::Vector)
+    return cdf.(Normal(), x) .* (d.b - d.a) .+ d.a
+end
+
 function to_standard_normal_space!(rv::RandomVariable, x::DataFrame)
-    x[!, rv.name] = quantile.(Normal(), cdf.(rv.dist, x[:, rv.name]))
+    x[!, rv.name] = _to_standard_normal_space(rv.dist, x[:, rv.name])
     return nothing
+end
+
+function _to_standard_normal_space(d::UnivariateDistribution, x::Vector)
+    return quantile.(Normal(), cdf.(d, x))
+end
+
+function _to_standard_normal_space(d::Normal, x::Vector)
+    if d.μ == 0.0 && d.σ == 1.0
+        return x
+    else
+        return (x .- d.μ) ./ d.σ
+    end
+end
+
+function _to_standard_normal_space(d::LogNormal, x::Vector)
+    return (log.(x) .- d.μ) ./ d.σ
+end
+
+function _to_standard_normal_space(d::Uniform, x::Vector)
+    return quantile.(Normal(), (x .- d.a) ./ (d.b - d.a))
 end
 
 dimensions(rv::RandomVariable) = 1

--- a/test/inputs/randomvariable.jl
+++ b/test/inputs/randomvariable.jl
@@ -36,4 +36,30 @@
     @test insupport(x, -1) == insupport(x.dist, -1)
     @test insupport(x, 0) == insupport(x.dist, 0)
     @test insupport(x, 1) == insupport(x.dist, 1)
+
+    @testset "SNS Mappings" begin
+        rvs = [
+            RandomVariable(Normal(), :x),
+            RandomVariable(Normal(3, 0.5), :x),
+            RandomVariable(LogNormal(), :x),
+            RandomVariable(Uniform(-2, 3), :x),
+            RandomVariable(Exponential(0.5), :x),
+        ]
+
+        n = 10^5
+
+        for rv in rvs
+            samples = sample(rv, n)
+            mapped = copy(samples)
+
+            to_standard_normal_space!(rv, mapped)
+
+            @test mean(mapped.x) ≈ 0.0 atol = 0.01
+            @test std(mapped.x) ≈ 1.0 atol = 0.01
+
+            to_physical_space!(rv, mapped)
+
+            samples.x == mapped.x
+        end
+    end
 end


### PR DESCRIPTION
This PR defines precise methods for the mappings between standard normal space and physical space for `Normal`, `LogNormal` and `Uniform` random variables. These should be more numerically stable for edge cases and also faster.

No mappings are performed for already standard normal rvs. This only concerns the independent case as mapping a `JointDistribution` is more complex.