### PR TITLE
Properly cd back to pwd on solver error

### DIFF
--- a/src/solvers/solver.jl
+++ b/src/solvers/solver.jl
@@ -12,16 +12,15 @@ function run(solver::Solver, folder::String)
     args = solver.args
 
     old_pwd = pwd()
-    cd(folder)
 
     out = joinpath(folder, basename(binary) * "UncertaintyQuantification.out")
     err = joinpath(folder, basename(binary) * "UncertaintyQuantification.err")
 
-    if !isempty(args)
-        Base.run(pipeline(`$binary $args $source`; stdout=out, stderr=err))
-    else
-        Base.run(pipeline(`$binary $source`; stdout=out, stderr=err))
-    end
+    p = pipeline(
+        !isempty(args) ? `$binary $args $source` : `$binary $source`; stdout=out, stderr=err
+    )
 
-    return cd(old_pwd)
+    cd(() -> run(p), folder)
+
+    return nothing
 end

--- a/test/solvers/solvers.jl
+++ b/test/solvers/solvers.jl
@@ -22,4 +22,10 @@
     radius = map(x -> parse(Float64, x), readlines(joinpath(tmp, "out.txt")))
 
     @test radius[1] == sqrt(0.5^2 + 0.5^2)
+
+    current_dir = pwd()
+
+    @test_throws Base.IOError run(Solver("this/solver/does/not/exist", "in.txt"), tmp)
+
+    @test pwd() == current_dir
 end


### PR DESCRIPTION
By using `cd` in connection with a `folder` it will automatically go back to the current directory even when the `Solver` fails to run.

Closes #109 