### PR TITLE
Fix sobolindices for multiple external models

### DIFF
--- a/src/sensitivity/sobolindices.jl
+++ b/src/sensitivity/sobolindices.jl
@@ -31,7 +31,7 @@ function sobolindices(
 
     VY = var([fA; fB]; dims=1)
 
-    for (i, name) in enumerate(random_names)
+    for name in random_names
         ABi = select(A, Not(name))
         ABi[:, name] = B[:, name]
 


### PR DESCRIPTION
The loop created separate folders when executed with multiple external solvers. This way, it makes use of the convenience function which will run the models in the same timestamped folder.

Closes #113 