### PR TITLE
Fix solver for relative workdir

### DIFF
--- a/src/solvers/solver.jl
+++ b/src/solvers/solver.jl
@@ -2,6 +2,12 @@ struct Solver
     path::String
     source::String
     args::String
+    function Solver(path::String, source::String, args::String)
+        if !isabspath(path)
+            @warn "Specified solver path is not an absolute path. Make sure $path is in your environmental varibles path."
+        end
+        return new(path, source, args)
+    end
 end
 
 Solver(path::String, source::String; args::String="") = Solver(path, source, args)
@@ -13,8 +19,8 @@ function run(solver::Solver, folder::String)
 
     old_pwd = pwd()
 
-    out = joinpath(folder, basename(binary) * "UncertaintyQuantification.out")
-    err = joinpath(folder, basename(binary) * "UncertaintyQuantification.err")
+    out = basename(binary) * "UncertaintyQuantification.out"
+    err = basename(binary) * "UncertaintyQuantification.err"
 
     p = pipeline(
         !isempty(args) ? `$binary $args $source` : `$binary $source`; stdout=out, stderr=err

--- a/src/solvers/solver.jl
+++ b/src/solvers/solver.jl
@@ -4,7 +4,7 @@ struct Solver
     args::String
     function Solver(path::String, source::String, args::String)
         if !isabspath(path)
-            @warn "Specified solver path is not an absolute path. Make sure $path is in your environmental varibles path."
+            @warn "Solver path is not absolute. Make sure $path is on your PATH."
         end
         return new(path, source, args)
     end

--- a/test/solvers/solvers.jl
+++ b/test/solvers/solvers.jl
@@ -27,7 +27,7 @@
 
     @test_logs (
         :warn,
-        "Specified solver path is not an absolute path. Make sure this_path_is_not_absolute is in your environmental varibles path.",
+        "Solver path is not absolute. Make sure this_path_is_not_absolute is on your PATH.",
     ) Solver("this_path_is_not_absolute", "in.txt")
 
     @test_throws Base.IOError run(

--- a/test/solvers/solvers.jl
+++ b/test/solvers/solvers.jl
@@ -25,7 +25,12 @@
 
     current_dir = pwd()
 
-    @test_throws Base.IOError run(Solver("this/solver/does/not/exist", "in.txt"), tmp)
+    @test_warn "Specified solver path is not an absolute path. Make sure this_path_is_not_absolute is in your environmental varibles path." Solver(
+        "this_path_is_not_absolute", "in.txt"
+    )
 
+    @test_throws Base.IOError run(
+        Solver(joinpath(pwd(), "this/solver/does/not/exist"), "in.txt"), tmp
+    )
     @test pwd() == current_dir
 end

--- a/test/solvers/solvers.jl
+++ b/test/solvers/solvers.jl
@@ -25,9 +25,10 @@
 
     current_dir = pwd()
 
-    @test_warn "Specified solver path is not an absolute path. Make sure this_path_is_not_absolute is in your environmental varibles path." Solver(
-        "this_path_is_not_absolute", "in.txt"
-    )
+    @test_logs (
+        :warn,
+        "Specified solver path is not an absolute path. Make sure this_path_is_not_absolute is in your environmental varibles path.",
+    ) Solver("this_path_is_not_absolute", "in.txt")
 
     @test_throws Base.IOError run(
         Solver(joinpath(pwd(), "this/solver/does/not/exist"), "in.txt"), tmp


### PR DESCRIPTION
Add a check on solver path.
        
- stdout and stderr from solver run do not depend anymore on relative paths
- a warning will be throw when he solver has a relative path