### PR TITLE
Fix map_from_bases for single rv

### DIFF
--- a/src/models/pce/pcebases.jl
+++ b/src/models/pce/pcebases.jl
@@ -106,7 +106,7 @@ function map_from_base(_::HermiteBasis, x::AbstractVector)
 end
 
 function map_from_bases(Ψ::PolynomialChaosBasis, x::AbstractMatrix)
-    return mapreduce((b, xᵢ) -> map_from_base(b, xᵢ), hcat, Ψ.bases, eachcol(x))
+    return hcat(map((b, xᵢ) -> map_from_base(b, xᵢ), Ψ.bases, eachcol(x))...)
 end
 
 function quadrature_nodes(n::Int, _::LegendreBasis)

--- a/src/models/pce/polynomialchaosexpansion.jl
+++ b/src/models/pce/polynomialchaosexpansion.jl
@@ -49,11 +49,13 @@ function polynomialchaos(
     deterministic_inputs = filter(i -> isa(i, DeterministicUQInput), inputs)
     random_names = names(random_inputs)
 
-    nodes =
-        mapreduce(collect, hcat, Iterators.product(quadrature_nodes.(Ψ.p + 1, Ψ.bases)...))'
+    nodes = mapreduce(
+        n -> [n...]', vcat, Iterators.product(quadrature_nodes.(Ψ.p + 1, Ψ.bases)...)
+    )
     weights = map(prod, Iterators.product(quadrature_weights.(Ψ.p + 1, Ψ.bases)...))
 
     samples = DataFrame(map_from_bases(Ψ, nodes), random_names)
+
     to_physical_space!(random_inputs, samples)
 
     if !isempty(deterministic_inputs)


### PR DESCRIPTION
With this commit `map_from_bases` returns a `Matrix` regardless if one or more random variables are used. It also makes the `nodes` of the gauss quadrature a proper `Matrix` instead of an `adjoint`.

Afterwards #126 can be simplified and merged.