### PR TITLE
Adds adaptive subset infinity, and subset simulation logging

### DIFF
--- a/demo/reliability/cantilever.jl
+++ b/demo/reliability/cantilever.jl
@@ -45,7 +45,9 @@ println(
 )
 
 # Compute probability of failure using Importance Sampling
-pf, β, dp, α = probability_of_failure([inertia, displacement], df -> max_displacement .- df.w, inputs, FORM())
+pf, β, dp, α = probability_of_failure(
+    [inertia, displacement], df -> max_displacement .- df.w, inputs, FORM()
+)
 is = ImportanceSampling(10^4, β, dp, α)
 
 is_pf, is_cov, is_samples = probability_of_failure(
@@ -76,4 +78,26 @@ subset_pf, subset_cov, subset_samples = probability_of_failure(
 
 println(
     "Subset Simulation probability of failure: $subset_pf ($(size(subset_samples, 1)) model evaluations)",
+)
+
+# Compute probability of failure using conditional Subset Sampling
+subset_inf = UncertaintyQuantification.SubSetInfinity(2000, 0.1, 10, 0.5)
+
+subset_pf_inf, subset_cov_inf, subset_samples_inf = probability_of_failure(
+    [inertia, displacement], df -> max_displacement .- df.w, inputs, subset_inf
+)
+
+println(
+    "Subset infinity probability of failure: $subset_pf_inf ($(size(subset_samples_inf, 1)) model evaluations)",
+)
+
+# Compute probability of failure using adaptive Subset Sampling
+subset_adap = UncertaintyQuantification.SubSetInfinityAdaptive(2000, 0.1, 10, 1, 1)
+
+subset_pf_adap, subset_cov_adap, subset_samples_adap = probability_of_failure(
+    [inertia, displacement], df -> max_displacement .- df.w, inputs, subset_adap
+)
+
+println(
+    "Subset infinity adaptive probability of failure: $subset_pf_adap ($(size(subset_samples_adap, 1)) model evaluations)",
 )

--- a/src/UncertaintyQuantification.jl
+++ b/src/UncertaintyQuantification.jl
@@ -83,6 +83,7 @@ export ResponseSurface
 export SobolSampling
 export Solver
 export SubSetInfinity
+export SubSetInfinityAdaptive
 export SubSetSimulation
 export TwoLevelFactorial
 

--- a/src/simulations/subset.jl
+++ b/src/simulations/subset.jl
@@ -128,16 +128,15 @@ mutable struct SubSetInfinityAdaptive <: AbstractSubSetSimulation
 
     function SubSetInfinityAdaptive(
         n::Integer, target::Float64, levels::Integer, λ::Real, Na::Integer
-    )
+    ) 
         number_of_seeds = Int64(max(1, ceil(n * target)))
 
         (Na <= number_of_seeds) ||
             error("Number of partitions Na must be less than `n` * `target`")
         (mod(number_of_seeds, Na) == 0) ||
             error("Number of partitions Na must be a multiple of `n` * `target`")
-        (0 <= λ <= 1) || error(
-            "Scaling parameter must be between 0.0 and 1.0. A good initial choice is 1.0",
-        )
+        (0 <= λ <= 1) ||
+            error("Scaling parameter must be between 0.0 and 1.0. A good initial choice is 1.0")
         return new(n, target, levels, 1, Na, 1)
     end
 end
@@ -392,16 +391,14 @@ function nextlevelsamples(
             sim_i,
         )
 
-        samples_per_seed = Int64(
-            floor(N_samples_per_partition / length(performance_partition[i]))
-        )
+        samples_per_seed = Int64(floor(N_samples_per_partition / length(performance_partition[i])))
         p_check = repeat(performance_partition[i], samples_per_seed)
 
         a = 1 - mean(nextperformance .== p_check)   # Calculate acceptance rate
 
         λ = λ * exp(1 / sqrt(i) * (a - a_star))     # Estimate new scaling factor for proposal variance
 
-        @info "Estimated acceptance" a
+        @debug "Estimated acceptance" a
 
         push!(next_samples, nextsamples)
         push!(next_performance, nextperformance)

--- a/src/simulations/subset.jl
+++ b/src/simulations/subset.jl
@@ -67,7 +67,7 @@ struct SubSetInfinity <: AbstractSubSetSimulation
     s::Real
 
     function SubSetInfinity(n::Integer, target::Float64, levels::Integer, s::Real)
-        (0 <= s <= 1) || error("standard deviation must be between 0.0")
+        (0 <= s <= 1) || error("standard deviation must be between 0.0 and 1.0")
         return new(n, target, levels, s)
     end
 end

--- a/src/simulations/subset.jl
+++ b/src/simulations/subset.jl
@@ -128,11 +128,16 @@ mutable struct SubSetInfinityAdaptive <: AbstractSubSetSimulation
 
     function SubSetInfinityAdaptive(
         n::Integer, target::Float64, levels::Integer, λ::Real, Na::Integer
-    )   
-        (mod(n, Na) == 0) ||
-            error("Number of partitions Na must be a multiple of n")
-        (0 <= λ <= 1) ||
-            error("Scaling parameter must be between 0.0 and 1.0. A good initial choice is 1.0")
+    )
+        number_of_seeds = Int64(max(1, ceil(n * target)))
+
+        (Na <= number_of_seeds) ||
+            error("Number of partitions Na must be less than `n` * `target`")
+        (mod(number_of_seeds, Na) == 0) ||
+            error("Number of partitions Na must be a multiple of `n` * `target`")
+        (0 <= λ <= 1) || error(
+            "Scaling parameter must be between 0.0 and 1.0. A good initial choice is 1.0",
+        )
         return new(n, target, levels, 1, Na, 1)
     end
 end
@@ -387,7 +392,9 @@ function nextlevelsamples(
             sim_i,
         )
 
-        samples_per_seed = Int64(floor(N_samples_per_partition / Ns))
+        samples_per_seed = Int64(
+            floor(N_samples_per_partition / length(performance_partition[i]))
+        )
         p_check = repeat(performance_partition[i], samples_per_seed)
 
         a = 1 - mean(nextperformance .== p_check)   # Calculate acceptance rate

--- a/src/simulations/subset.jl
+++ b/src/simulations/subset.jl
@@ -99,6 +99,12 @@ Defines the properties of a Subset-∞ simulation where `n` is the number of ini
 `target` is the target probability of failure at each level, `levels` is the maximum number
 of levels and `s` is the standard deviation for the proposal samples.
 
+
+    Idea behind this algorithm is to adaptively select the correlation parameter of s
+    (per dimension) at each intermediate level, by simulating a subset N_a of the chains
+    (which must be choosen without replacement at random) and modifying the acceptance rate towards the optiming
+    α_star = 0.44
+
 # Examples
 
 ```jldoctest
@@ -112,16 +118,17 @@ SubSetInfinity(100, 0.1, 10, 0.5)
 
 [patelliEfficientMonteCarlo2015](@cite)
 """
-struct SubSetInfinityAdaptive <: AbstractSubSetSimulation
+mutable struct SubSetInfinityAdaptive <: AbstractSubSetSimulation
     n::Integer
     target::Float64
     levels::Integer
     λ::Real
-    Na::Integer
+    Na::Integer     # Probably needs to be a multiple of N
+    s :: Real
 
     function SubSetInfinityAdaptive(n::Integer, target::Float64, levels::Integer, λ::Real, Na::Integer)
         (0 <= λ <= 1) || error("Scaling parameter must be between 0.0 and 1.0. A good initial choice is")
-        return new(n, target, levels, λ, Na)
+        return new(n, target, levels, 1, Na, 1)
     end
 end
 

--- a/src/simulations/subset.jl
+++ b/src/simulations/subset.jl
@@ -130,6 +130,8 @@ function probability_of_failure(
             cov[i] = estimate_cov(Iᵢ, pf[i], sim.n)
         end
 
+        @info "Subset level $i"  pf[i]  threshold[i] cov[i]
+
         ## Break the loop
         if threshold[i] <= 0 || i == sim.levels
             break
@@ -262,6 +264,9 @@ function nextlevelsamples(
 
     reject = nextlevelperformance .> threshold
 
+    α = 1 - mean(reject)
+    @info "acceptance rate" α
+    
     nextlevelsamples[reject, :] = samples[reject, :]
     nextlevelperformance[reject] = performance[reject]
 

--- a/src/simulations/subset.jl
+++ b/src/simulations/subset.jl
@@ -96,8 +96,8 @@ Implementation of: Papaioannou, Iason, et al. "MCMC algorithms for subset simula
 
 Defines the properties of a Subset-∞ adaptive where `n` is the number of initial samples,
 `target` is the target probability of failure at each level, `levels` is the maximum number
-of levels and `λ` (λ = 1 recommended) is the initial scaling parameter and Na is the number of 
-subset partitions. The initial variance of the proposal distribution is λ.
+of levels and `λ` (λ = 1 recommended) is the initial scaling parameter and `Na` is the number of 
+subset partitions. The initial variance of the proposal distribution is `λ`.
 
 
 Idea behind this algorithm is to adaptively select the correlation parameter of s
@@ -109,7 +109,7 @@ at each intermediate level, by simulating a subset N_a of the chains
 
 ```jldoctest
 julia> SubSetInfinityAdaptive(100, 0.1, 10, 4, 1)
-SubSetInfinity(100, 0.1, 10, 0.5)
+SubSetInfinityAdaptive(100, 0.1, 10, 4, 1)
 ```
 
 # References
@@ -129,10 +129,10 @@ mutable struct SubSetInfinityAdaptive <: AbstractSubSetSimulation
     function SubSetInfinityAdaptive(
         n::Integer, target::Float64, levels::Integer, λ::Real, Na::Integer
     )   
-        (mod(n, Na) ==0) ||
-            error("Number of partitions must Na be a multiple of n")
+        (mod(n, Na) == 0) ||
+            error("Number of partitions Na must be a multiple of n")
         (0 <= λ <= 1) ||
-            error("Scaling parameter must be between 0.0 and 1.0. A good initial choice is")
+            error("Scaling parameter must be between 0.0 and 1.0. A good initial choice is 1.0")
         return new(n, target, levels, 1, Na, 1)
     end
 end

--- a/test/reliability/probabilityoffailure.jl
+++ b/test/reliability/probabilityoffailure.jl
@@ -81,7 +81,7 @@
         pf, _, _ = probability_of_failure(g, F, [x1, x2, y], subset)
 
         # 95% conf intervals estimated from 1000 runs
-        @test 3.14e-11 < pf < 3.4e-9
+        @test 3.14e-11 < pf < 3.4e-10
 
     end
 end

--- a/test/reliability/probabilityoffailure.jl
+++ b/test/reliability/probabilityoffailure.jl
@@ -75,5 +75,13 @@
 
         # 95% conf intervals estimated from 1000 runs
         @test 1.8e-11 < pf < 1.6e-9
+    
+        subset = SubSetInfinityAdaptive(10^4, 0.1, 20, 1, 4)
+
+        pf, _, _ = probability_of_failure(g, F, [x1, x2, y], subset)
+
+        # 95% conf intervals estimated from 1000 runs
+        @test 3.14e-11 < pf < 3.4e-9
+
     end
 end

--- a/test/simulations/subset.jl
+++ b/test/simulations/subset.jl
@@ -18,3 +18,43 @@
         2000, 0.2, 10, Uniform(-4, 4)
     )
 end
+
+@testset "SubSetInfinity" begin
+    subset = SubSetInfinity(2000, 0.2, 10, 0.5)
+
+    @test isa(subset, SubSetInfinity)
+    @test subset.n == 2000
+    @test subset.target == 0.2
+    @test subset.levels == 10
+    @test subset.s == 0.5
+
+    @test_throws ErrorException("standard deviation must be between 0.0 and 1.0") SubSetInfinity(
+        2000, 0.2, 10, 2.0
+    )
+    @test_throws ErrorException("standard deviation must be between 0.0 and 1.0") SubSetInfinity(
+        2000, 0.2, 10, -1.0
+    )
+end
+
+@testset "SubSetInfinityAdaptive" begin
+    subset = SubSetInfinityAdaptive(2000, 0.2, 10, 1, 4)
+
+    @test isa(subset, SubSetInfinityAdaptive)
+    @test subset.n == 2000
+    @test subset.target == 0.2
+    @test subset.levels == 10
+    @test subset.λ == 1
+    @test subset.Na == 4
+
+    @test_throws ErrorException(
+        "Scaling parameter must be between 0.0 and 1.0. A good initial choice is 1.0"
+    ) SubSetInfinityAdaptive(2000, 0.1, 10, 2.0, 4)
+
+    @test_throws ErrorException(
+        "Scaling parameter must be between 0.0 and 1.0. A good initial choice is 1.0"
+    ) SubSetInfinityAdaptive(2000, 0.1, 10, -2.0, 4)
+    
+    @test_throws ErrorException("Number of partitions Na must be a multiple of n") SubSetInfinityAdaptive(
+        2000, 0.1, 10, -2.0, 9
+    )
+end

--- a/test/simulations/subset.jl
+++ b/test/simulations/subset.jl
@@ -54,7 +54,11 @@ end
         "Scaling parameter must be between 0.0 and 1.0. A good initial choice is 1.0"
     ) SubSetInfinityAdaptive(2000, 0.1, 10, -2.0, 4)
     
-    @test_throws ErrorException("Number of partitions Na must be a multiple of n") SubSetInfinityAdaptive(
-        2000, 0.1, 10, -2.0, 9
+    @test_throws ErrorException("Number of partitions Na must be a multiple of `n` * `target`") SubSetInfinityAdaptive(
+        2000, 0.1, 10, 1, 9
+    )
+
+    @test_throws ErrorException("Number of partitions Na must be less than `n` * `target`") SubSetInfinityAdaptive(
+        2000, 0.1, 10, 1, 400
     )
 end


### PR DESCRIPTION
An implementation of adaptive conditional subset simulation (subset infinity) from [1,2].

The idea behind the algorithm is to adaptively tune the standard deviation (`s` in our implementation) of the proposal distribution towards an optimal acceptance rate. Which they say is `a_star = 0.44`. 

For each level, the algorithm iteratively computes the acceptance rate. This is done by partitioning the seeds (say into 4), and running usual subset infinity 4 times, and computing a scaling factor `λ`, which updates the std `s_new = min(1, λ*s)`. In this case, `s` is updated 4 times for each level.

Here's my data structure:

```Julia
mutable struct SubSetInfinityAdaptive <: AbstractSubSetSimulation
    n::Integer
    target::Float64
    levels::Integer
    λ::Real
    Na::Integer   
    s::Real
end
```

The new properties: 
*  `λ`: initial scaling factor. Recommended to be set to `1`
* `Na`: the number of times to update the scaling factor in each level. The number of seeds is partitioned this many times

If `Na=1`, the update will only happen at each level.

Note, in my implementation the structures has to be mutable, since I'm updating and saving `λ` at each level. Perhaps there's a better way, but this way I was able to use the same `probability_of_failure` function.

Here's the constructor:

```Julia
    function SubSetInfinityAdaptive(
        n::Integer, target::Float64, levels::Integer, λ::Real, Na::Integer
    ) 
        number_of_seeds = Int64(max(1, ceil(n * target)))

        (Na <= number_of_seeds) ||
            error("Number of partitions Na must be less than `n` * `target`")
        (mod(number_of_seeds, Na) == 0) ||
            error("Number of partitions Na must be a multiple of `n` * `target`")
        (0 <= λ <= 1) ||
            error("Scaling parameter must be between 0.0 and 1.0. A good initial choice is 1.0")
        return new(n, target, levels, 1, Na, 1)
    end
```

The second check is important to ensure the seeds can be partitioned into `Na`.

### Further future improvements

* Have a different scaling factor for each dimension. The papers state that the sample std and mean can be computed between levels, allowing for the proposal's variance to be different in each dimension. This allows for sensitive dimensions to be determined by algorithm.

### LOGGING

It would be good to **Logging.jl** the progress of the subset simulation algorithms. I've been running quite expensive simulations, and it's useful to print progress. I've added some, however I think they can be improved... Currently too much information is being printed.

### Refs

[1] Papaioannou, I., Betz, W., Zwirglmaier, K., & Straub, D. (2015). MCMC algorithms for subset simulation. Probabilistic Engineering Mechanics, 41, 89-103.

[2] Chan, J., Papaioannou, I., & Straub, D. (2022). An adaptive subset simulation algorithm for system reliability analysis with discontinuous limit states. Reliability Engineering & System Safety, 225, 108607.