### PR TITLE
Allow for passing of different fdm methods

### DIFF
--- a/src/UncertaintyQuantification.jl
+++ b/src/UncertaintyQuantification.jl
@@ -52,11 +52,14 @@ export UQType
 
 # Structs
 export EmpiricalDistribution
+export BackwardFiniteDifferences
 export BoxBehnken
 export CentralComposite
+export CentralFiniteDifferences
 export ExternalModel
 export Extractor
 export FORM
+export ForwardFiniteDifferences
 export FractionalFactorial
 export FullFactorial
 export GaussianCopula

--- a/src/UncertaintyQuantification.jl
+++ b/src/UncertaintyQuantification.jl
@@ -131,6 +131,7 @@ include("models/responsesurface.jl")
 include("models/pce/pcebases.jl")
 include("models/pce/polynomialchaosexpansion.jl")
 
+include("sensitivity/finitedifferences.jl")
 include("sensitivity/gradient.jl")
 
 include("simulations/doe.jl")

--- a/src/reliability/form.jl
+++ b/src/reliability/form.jl
@@ -6,7 +6,7 @@ struct FORM
     function FORM(
         n::Integer=10,
         tol::Real=1e-3;
-        fdm::FiniteDifferencesMethod=CentralFiniteDifferences(3, 1),
+        fdm::FiniteDifferencesMethod=CentralFiniteDifferences(3),
     )
         return new(n, tol, fdm)
     end

--- a/src/reliability/form.jl
+++ b/src/reliability/form.jl
@@ -1,9 +1,14 @@
 struct FORM
     n::Integer
     tol::Real
+    fdm::FiniteDifferencesMethod
 
-    function FORM(n::Integer=10, tol::Real=1e-3)
-        return new(n, tol)
+    function FORM(
+        n::Integer=10,
+        tol::Real=1e-3;
+        fdm::FiniteDifferencesMethod=CentralFiniteDifferences(3, 1),
+    )
+        return new(n, tol, fdm)
     end
 end
 
@@ -35,7 +40,9 @@ function probability_of_failure(
         to_physical_space!(inputs, physical)
         physical = hcat(physical, parameters)
 
-        H = gradient_in_standard_normal_space(G, inputs, physical, :performance)
+        H = gradient_in_standard_normal_space(
+            G, inputs, physical, :performance; fdm=sim.fdm
+        )
 
         H = map(n -> H[n], random_names)
 

--- a/src/sensitivity/finitedifferences.jl
+++ b/src/sensitivity/finitedifferences.jl
@@ -1,0 +1,16 @@
+abstract type FiniteDifferencesMethod end
+
+struct CentralFiniteDifferences <: FiniteDifferencesMethod
+    order::Int
+    derivative::Int
+end
+
+struct ForwardFiniteDifferences <: FiniteDifferencesMethod
+    order::Int
+    derivative::Int
+end
+
+struct BackwardFiniteDifferences <: FiniteDifferencesMethod
+    order::Int
+    derivative::Int
+end

--- a/src/sensitivity/finitedifferences.jl
+++ b/src/sensitivity/finitedifferences.jl
@@ -3,14 +3,26 @@ abstract type FiniteDifferencesMethod end
 struct CentralFiniteDifferences <: FiniteDifferencesMethod
     order::Int
     derivative::Int
+
+    function CentralFiniteDifferences(order::Int, derivative::Int=1)
+        return new(order, derivative)
+    end
 end
 
 struct ForwardFiniteDifferences <: FiniteDifferencesMethod
     order::Int
     derivative::Int
+
+    function ForwardFiniteDifferences(order::Int, derivative::Int=1)
+        return new(order, derivative)
+    end
 end
 
 struct BackwardFiniteDifferences <: FiniteDifferencesMethod
     order::Int
     derivative::Int
+
+    function BackwardFiniteDifferences(order::Int, derivative::Int=1)
+        return new(order, derivative)
+    end
 end

--- a/src/sensitivity/gradient.jl
+++ b/src/sensitivity/gradient.jl
@@ -3,7 +3,7 @@ function gradient(
     inputs::Vector{<:UQInput},
     x::DataFrame,
     output::Symbol;
-    fdm::FiniteDifferencesMethod=CentralFiniteDifferences(3, 1),
+    fdm::FiniteDifferencesMethod=CentralFiniteDifferences(3),
 )
     samples = copy(x)
 
@@ -30,7 +30,7 @@ function gradient_in_standard_normal_space(
     inputs::Vector{<:UQInput},
     reference::DataFrame,
     output::Symbol;
-    fdm::FiniteDifferencesMethod=CentralFiniteDifferences(3, 1),
+    fdm::FiniteDifferencesMethod=CentralFiniteDifferences(3),
 )
     samples = copy(reference)
 

--- a/test/sensitivity/gradient.jl
+++ b/test/sensitivity/gradient.jl
@@ -10,5 +10,27 @@
 
         @test isapprox(g.x, 8.0; rtol=0.001)
         @test isapprox(g.y, -2.0; rtol=0.001)
+
+        g = gradient(
+            [model],
+            [p, x, y],
+            DataFrame(; p=2.0, x=2.0, y=1.0),
+            :f;
+            fdm=ForwardFiniteDifferences(3, 1),
+        )
+
+        @test isapprox(g.x, 8.0; rtol=0.001)
+        @test isapprox(g.y, -2.0; rtol=0.001)
+
+        g = gradient(
+            [model],
+            [p, x, y],
+            DataFrame(; p=2.0, x=2.0, y=1.0),
+            :f;
+            fdm=BackwardFiniteDifferences(3, 1),
+        )
+
+        @test isapprox(g.x, 8.0; rtol=0.001)
+        @test isapprox(g.y, -2.0; rtol=0.001)
     end
 end


### PR DESCRIPTION
Currently everywhere `forward_fdm(2,1)` is used to compute the first derivatives. This PR allows for passing of different methods using the new structs `ForwardFiniteDifferences`, `CentralFiniteDifferences`, `BackwardFiniteDifferences`.

All methods default to `CentralFiniteDifferences(3,1)`.

Closes #106.