### PR TITLE
Slurm job array interface

### DIFF
--- a/demo/models/openmc_TBR.py
+++ b/demo/models/openmc_TBR.py
@@ -1,0 +1,114 @@
+import sys
+import os
+import openmc
+
+import json
+import pandas as pd
+
+# MATERIALS
+
+breeder_material = openmc.Material()  # lithium lead chemical equation is Pb84.2Li15.8
+breeder_material.add_element('Pb', 84.2, percent_type='ao')
+# 50% enriched lithium 6, natural percentage of lithium 6 is just 7% 
+breeder_material.add_element('Li', 15.8, percent_type='ao', enrichment={{{:Enrich}}}, enrichment_target='Li6', enrichment_type='ao')
+breeder_material.set_density('atom/b-cm', 3.2720171e-2)  # around 11 g/cm3
+
+
+steel = openmc.Material()
+steel.set_density('g/cm3', 7.75)
+steel.add_element('Fe', 0.95, percent_type='wo')
+steel.add_element('C', 0.05, percent_type='wo')
+
+mats = openmc.Materials([breeder_material, steel])
+
+
+# GEOMETRY
+
+# surfaces
+vessel_inner = openmc.Sphere(r=500)
+first_wall_outer_surface = openmc.Sphere(r=510)
+breeder_blanket_outer_surface = openmc.Sphere(r={{{:OuterWall}}}, boundary_type='vacuum')
+
+
+# cells
+inner_vessel_region = -vessel_inner
+inner_vessel_cell = openmc.Cell(region=inner_vessel_region)
+
+first_wall_region = -first_wall_outer_surface & +vessel_inner
+first_wall_cell = openmc.Cell(region=first_wall_region)
+first_wall_cell.fill = steel
+
+breeder_blanket_region = +first_wall_outer_surface & -breeder_blanket_outer_surface
+breeder_blanket_cell = openmc.Cell(region=breeder_blanket_region)
+breeder_blanket_cell.fill = breeder_material
+
+universe = openmc.Universe(cells=[inner_vessel_cell, first_wall_cell, breeder_blanket_cell])
+geom = openmc.Geometry(universe)
+
+
+# SIMULATION SETTINGS
+
+# Instantiate a Settings object
+sett = openmc.Settings()
+sett.batches = 10
+sett.inactive = 0
+sett.particles = 500
+sett.run_mode = 'fixed source'
+
+# Create a DT point source
+source = openmc.Source()
+source.space = openmc.stats.Point((0, 0, 0))
+source.angle = openmc.stats.Isotropic()
+source.energy = openmc.stats.Discrete([14e6], [1])
+sett.source = source
+
+
+tallies = openmc.Tallies()
+
+# added a cell tally for tritium production
+cell_filter = openmc.CellFilter(breeder_blanket_cell)
+tbr_tally = openmc.Tally(name='TBR')
+tbr_tally.filters = [cell_filter]
+tbr_tally.scores = ['(n,Xt)']  # Where X is a wildcard character, this catches any tritium production
+# this allows the tally to be recorded per nuclide so we can see which one contributes to tritium production more
+tbr_tally.nuclides = [openmc.Nuclide('Li6'), openmc.Nuclide('Li7')] 
+tallies.append(tbr_tally)
+
+
+# Run OpenMC!
+model = openmc.model.Model(geom, mats, sett, tallies)
+
+model.export_to_xml()
+
+os.system('openmc')
+
+# open the results file
+sp = openmc.StatePoint("statepoint.10.h5")
+
+# access the tally using pandas dataframes
+tbr_tally = sp.get_tally(name='TBR')
+df = tbr_tally.get_pandas_dataframe()
+
+# prints the contents of the dataframe
+df
+
+# sums up all the values in the mean column
+tbr_tally_result = df['mean'].sum()
+
+# sums up all the values in the std. dev. column
+tbr_tally_std_dev = df['std. dev.'].sum()
+
+TBR_dict = {'TBR': tbr_tally_result,
+            'TBR_std': tbr_tally_std_dev
+            }
+
+# json_object = json.dumps(TBR_dict)
+
+with open("openmc.out", "w") as outfile:
+    outfile.write(tbr_tally_result)
+
+
+#df_out = pd.DataFrame([tbr_tally_result], columns=['TBR'])
+#df_out.to_csv("TBR.csv")
+#df_out.to_json("TBR.json")
+

--- a/demo/models/openmc_TBR.py
+++ b/demo/models/openmc_TBR.py
@@ -89,26 +89,12 @@ sp = openmc.StatePoint("statepoint.10.h5")
 tbr_tally = sp.get_tally(name='TBR')
 df = tbr_tally.get_pandas_dataframe()
 
-# prints the contents of the dataframe
-df
-
 # sums up all the values in the mean column
 tbr_tally_result = df['mean'].sum()
 
 # sums up all the values in the std. dev. column
 tbr_tally_std_dev = df['std. dev.'].sum()
 
-TBR_dict = {'TBR': tbr_tally_result,
-            'TBR_std': tbr_tally_std_dev
-            }
-
-# json_object = json.dumps(TBR_dict)
 
 with open("openmc.out", "w") as outfile:
-    outfile.write(tbr_tally_result)
-
-
-#df_out = pd.DataFrame([tbr_tally_result], columns=['TBR'])
-#df_out.to_csv("TBR.csv")
-#df_out.to_json("TBR.json")
-
+    outfile.write(f"{tbr_tally_result} {tbr_tally_std_dev}")

--- a/demo/reliability/slurm-openmc.jl
+++ b/demo/reliability/slurm-openmc.jl
@@ -7,7 +7,7 @@ using UncertaintyQuantification, DelimitedFiles
 # @everywhere using UncertaintyQuantification, DelimitedFiles
 
 E = RandomVariable(Normal(40, 60), :Enrich)
-O = RandomVariable(Uniform(530, 690), :OuterWALL)
+O = RandomVariable(Uniform(530, 690), :OuterWall)
 
 # Source/Extra files are expected to be in this folder
 sourcedir = joinpath(pwd() * "/../..", "demo/models")

--- a/demo/reliability/slurm-openmc.jl
+++ b/demo/reliability/slurm-openmc.jl
@@ -6,7 +6,7 @@ using UncertaintyQuantification, DelimitedFiles
 # addprocs(6; exeflags="--project")
 # @everywhere using UncertaintyQuantification, DelimitedFiles
 
-E = RandomVariable(Normal(40, 60), :Enrich)
+E = RandomVariable(Uniform(40, 60), :Enrich)
 O = RandomVariable(Uniform(530, 690), :OuterWall)
 
 # Source/Extra files are expected to be in this folder

--- a/demo/reliability/slurm-openmc.jl
+++ b/demo/reliability/slurm-openmc.jl
@@ -1,0 +1,62 @@
+# Reference: https://opensees.berkeley.edu/wiki/index.php/Simply_supported_beam_modeled_with_two_dimensional_solid_elements
+using UncertaintyQuantification, DelimitedFiles
+
+# To run the model distributed add the desired workers and load the required packages with @everywhere
+# using Distributed, Formatting
+# addprocs(6; exeflags="--project")
+# @everywhere using UncertaintyQuantification, DelimitedFiles
+
+E = RandomVariable(Normal(40, 60), :Enrich)
+O = RandomVariable(Uniform(530, 690), :OuterWALL)
+
+# Source/Extra files are expected to be in this folder
+sourcedir = joinpath(pwd() * "/../..", "demo/models")
+
+# These files will be rendere through Mustach.jl and have values injected
+sourcefile = "openmc_TBR.py"
+
+# Dictionary to map format Strings (Formatting.jl) to variables
+numberformats = Dict(:E => ".8e")
+
+# UQ will create subfolders in here to run the solver and store the results
+workdir = joinpath(pwd(), "openmc_TBR")
+
+# Read output file and compute maximum (absolute) displacement
+# An extractor is based the working directory for the current sample
+TBR = Extractor(base -> begin
+    file = joinpath(base, "openmc.out")
+    data = readdlm(file, ' ')
+
+    return data[1]
+end, :TBR)
+
+openmc = Solver(
+    "python3", # path to OpenSees binary
+    "openmc_TBR.py";
+    args="", # (optional) extra arguments passed to the solver
+)
+
+slurm = SlurmInterface(;
+    name="UQ_slurm",
+    account="UKAEA-AP001-CPU",
+    partition="cclake",
+    nodes=1,
+    ntasks=1,
+    batchsize=200,
+    time="00:01:00",
+    extras=["module load openmc", "source ~/.virtualenvs/openmc/bin/activate"],
+)
+
+ext = ExternalModel(
+    sourcedir,
+    sourcefile,
+    TBR,
+    openmc;
+    workdir=workdir,
+    formats=numberformats,
+    slurm=slurm,
+)
+
+pf, samples = probability_of_failure(ext, df -> 1.0 .- df.TBR, [E, O], MonteCarlo(1000))
+
+println("Probability of failure: $pf")

--- a/demo/reliability/slurm-opensees.jl
+++ b/demo/reliability/slurm-opensees.jl
@@ -1,0 +1,61 @@
+# Reference: https://opensees.berkeley.edu/wiki/index.php/Simply_supported_beam_modeled_with_two_dimensional_solid_elements
+using UncertaintyQuantification, DelimitedFiles
+
+# To run the model distributed add the desired workers and load the required packages with @everywhere
+# using Distributed, Formatting
+# addprocs(6; exeflags="--project")
+# @everywhere using UncertaintyQuantification, DelimitedFiles
+
+E = RandomVariable(Normal(1000, 5), :E)
+
+# Source/Extra files are expected to be in this folder
+sourcedir = joinpath(pwd() * "/../..", "demo/models")
+
+# These files will be rendere through Mustach.jl and have values injected
+sourcefile = "supported-beam.tcl"
+
+# Dictionary to map format Strings (Formatting.jl) to variables
+numberformats = Dict(:E => ".8e")
+
+# UQ will create subfolders in here to run the solver and store the results
+workdir = joinpath(pwd(), "supported-beam")
+
+# Read output file and compute maximum (absolute) displacement
+# An extractor is based the working directory for the current sample
+disp = Extractor(base -> begin
+    file = joinpath(base, "displacement.out")
+    data = readdlm(file, ' ')
+
+    return maximum(abs.(data[:, 2]))
+end, :disp)
+
+opensees = Solver(
+    "OpenSees", # path to OpenSees binary
+    "supported-beam.tcl";
+    args="", # (optional) extra arguments passed to the solver
+)
+
+slurm = SlurmInterface(;
+    name="UQ_slurm",
+    account="UKAEA-AP001-CPU",
+    partition="cclake",
+    nodes=1,
+    ntasks=1,
+    batchsize=200,
+    time="24:00:00",
+    extras=["module load opensees", "module load openmc"],
+)
+
+ext = ExternalModel(
+    sourcedir,
+    sourcefile,
+    disp,
+    opensees;
+    workdir=workdir,
+    formats=numberformats,
+    slurm=slurm,
+)
+
+pf, samples = probability_of_failure(ext, df -> 0.35 .- df.disp, E, MonteCarlo(1000))
+
+println("Probability of failure: $pf")

--- a/src/UncertaintyQuantification.jl
+++ b/src/UncertaintyQuantification.jl
@@ -58,6 +58,7 @@ export BoxBehnken
 export CentralComposite
 export CentralFiniteDifferences
 export ExternalModel
+export SlurmInterface
 export Extractor
 export FaureSampling
 export FORM
@@ -126,6 +127,7 @@ include("inputs/copulas/gaussian.jl")
 include("inputs/jointdistribution.jl")
 
 include("solvers/solver.jl")
+include("solvers/slurm.jl")
 include("solvers/extractor.jl")
 
 include("models/externalmodel.jl")

--- a/src/models/externalmodel.jl
+++ b/src/models/externalmodel.jl
@@ -98,11 +98,7 @@ function evaluate!(
     n = size(df, 1)
     digits = ndigits(n)
 
-    ## get current dir
-
     for i = 1:n
-
-        ## set current dir
 
         path = joinpath(m.workdir, datetime, "sample-$(lpad(i, digits, "0"))")
         mkpath(path)
@@ -125,9 +121,7 @@ function evaluate!(
         end
     end
 
-    make_input(slurm)
-    launch(slurm)
-
+    run_slurm_Array(slurm, m, n)
 
     results = map(1:n) do i
         path = joinpath(m.workdir, datetime, "sample-$(lpad(i, digits, "0"))")

--- a/src/models/externalmodel.jl
+++ b/src/models/externalmodel.jl
@@ -48,7 +48,8 @@ function evaluate!(
     df::DataFrame;
     datetime::String=Dates.format(now(), "YYYY-mm-dd-HH-MM-SS"),
 )
-    if !isnothing(m.slurm) return evaluate!(m, df, datetime, m.slurm) end
+    if !isnothing(m.slurm) return evaluate!(m, df, m.slurm, datetime = datetime) end
+
     n = size(df, 1)
     digits = ndigits(n)
 
@@ -91,9 +92,9 @@ end
 
 function evaluate!(
     m::ExternalModel,
-    df::DataFrame;
+    df::DataFrame,
+    slurm::SlurmInterface;
     datetime::String=Dates.format(now(), "YYYY-mm-dd-HH-MM-SS"),
-    slurm::SlurmInterface
 )
     n = size(df, 1)
     digits = ndigits(n)
@@ -121,7 +122,7 @@ function evaluate!(
         end
     end
 
-    run_slurm_Array(slurm, m, n)
+    run_slurm_array(slurm, m, n, datetime)
 
     results = map(1:n) do i
         path = joinpath(m.workdir, datetime, "sample-$(lpad(i, digits, "0"))")

--- a/src/models/externalmodel.jl
+++ b/src/models/externalmodel.jl
@@ -7,6 +7,7 @@ struct ExternalModel <: UQModel
     extras::Vector{String}
     formats::Dict{Symbol,String}
     cleanup::Bool
+    slurm::Union{SlurmInterface, Nothing}
 
     function ExternalModel(
         sourcedir::String,
@@ -17,10 +18,11 @@ struct ExternalModel <: UQModel
         extras::Union{String,Vector{String}},
         formats::Dict{Symbol,String},
         cleanup::Bool,
+        slurm::Union{SlurmInterface, Nothing}
     )
         sources, extractors, extras = wrap.([sources, extractors, extras])
         return new(
-            sourcedir, sources, extractors, solver, workdir, extras, formats, cleanup
+            sourcedir, sources, extractors, solver, workdir, extras, formats, cleanup, slurm
         )
     end
 end
@@ -34,9 +36,10 @@ function ExternalModel(
     extras::Union{String,Vector{String}}=String[],
     formats::Dict{Symbol,String}=Dict{Symbol,String}(),
     cleanup::Bool=false,
+    slurm::SlurmInterface = nothing
 )
     return ExternalModel(
-        sourcedir, sources, extractors, solver, workdir, extras, formats, cleanup
+        sourcedir, sources, extractors, solver, workdir, extras, formats, cleanup, slurm
     )
 end
 
@@ -45,6 +48,7 @@ function evaluate!(
     df::DataFrame;
     datetime::String=Dates.format(now(), "YYYY-mm-dd-HH-MM-SS"),
 )
+    if !isnothing(m.slurm) return evaluate!(m, df, datetime, m.slurm) end
     n = size(df, 1)
     digits = ndigits(n)
 
@@ -83,6 +87,63 @@ function evaluate!(
     for (i, name) in enumerate(names(m.extractors))
         df[!, name] = results[i, :]
     end
+end
+
+function evaluate!(
+    m::ExternalModel,
+    df::DataFrame;
+    datetime::String=Dates.format(now(), "YYYY-mm-dd-HH-MM-SS"),
+    slurm::SlurmInterface
+)
+    n = size(df, 1)
+    digits = ndigits(n)
+
+    ## get current dir
+
+    for i = 1:n
+
+        ## set current dir
+
+        path = joinpath(m.workdir, datetime, "sample-$(lpad(i, digits, "0"))")
+        mkpath(path)
+
+        row = formatinputs(df[i, :], m.formats)
+
+        for file in m.sources
+            if isempty(file)
+                continue
+            end
+            tokens = Mustache.load(joinpath(m.sourcedir, file))
+
+            open(joinpath(path, file), "w") do io
+                render(io, tokens, row)
+            end
+        end
+
+        for file in m.extras
+            cp(joinpath(m.sourcedir, file), joinpath(path, file))
+        end
+    end
+
+    make_input(slurm)
+    launch(slurm)
+
+
+    results = map(1:n) do i
+        path = joinpath(m.workdir, datetime, "sample-$(lpad(i, digits, "0"))")
+        result = map(e -> e.f(path), m.extractors)
+        if m.cleanup
+            rm(path; recursive=true)
+        end
+        return result
+    end
+
+    results = hcat(results...)
+
+    for (i, name) in enumerate(names(m.extractors))
+        df[!, name] = results[i, :]
+    end
+
 end
 
 function formatinputs(row::DataFrameRow, formats::Dict{Symbol,String})

--- a/src/solvers/slurm.jl
+++ b/src/solvers/slurm.jl
@@ -1,0 +1,21 @@
+## Probably better to make a 'SlurmSolver' version of 'solver'
+
+struct SlurmInterface
+
+    name::String
+    account::String
+    nodes::Integer
+    ntasks::Integer
+    time::String
+    partition::String
+    extras::Vector{String}
+
+end
+
+function make_input(SlurmInterface)
+
+end
+
+function launch(SlurmInterface, ExternalModel )
+    
+end

--- a/src/solvers/slurm.jl
+++ b/src/solvers/slurm.jl
@@ -1,8 +1,7 @@
 ## Probably better to make a 'SlurmSolver' version of 'solver'
 
 struct SlurmInterface
-
-    name::String        # Does nothing
+    name::String
     account::String
     partition::String
     nodes::Integer
@@ -11,23 +10,21 @@ struct SlurmInterface
     extras::Vector{String}
     time::String
 
-    function SlurmInterface(;name::String, 
+    function SlurmInterface(;
+        name::String,
         account::String,
         partition::String,
         nodes::Integer,
         ntasks::Integer,
         batchsize::Integer,
         extras::Vector{String},
-        time::String)
-
+        time::String,
+    )
         return new(name, account, partition, nodes, ntasks, batchsize, extras, time)
     end
-
 end
 
 function run_slurm_array(SI, m, n, path)
-    #slurm_array.sh
-
     binary = m.solver.path
     source = m.solver.source
     args = m.solver.args
@@ -41,36 +38,34 @@ function run_slurm_array(SI, m, n, path)
     fname = "slurm_array.sh"
     dirpath = joinpath(m.workdir, path)
     fpath = joinpath(dirpath, fname)
-    
+
     open(fpath, "w") do file
         write(file, "#!/bin/bash -l\n")
         write(file, "#SBATCH -A $(SI.account)\n")
         write(file, "#SBATCH -p $(SI.partition)\n")
-        write(file, "#SBATCH -J UQ_array\n")
+        write(file, "#SBATCH -J $(SI.name)\n")
         write(file, "#SBATCH --nodes=$(SI.nodes)\n")
         write(file, "#SBATCH --ntasks=$(SI.ntasks)\n")
-        write(file, "#SBATCH --time=$(time)\n")
+        write(file, "#SBATCH --time=$(SI.time)\n")
         write(file, "#SBATCH --output=UncertaintyQuantification_%A-%a.out\n")
         write(file, "#SBATCH --error=UncertaintyQuantification_%A-%a.err\n")
         write(file, "#SBATCH --array=[1-$(n)]%$(SI.batchsize)\n")
-        write(file,"\n\n\n")
-        write(file,"#### EXTRAS ####\n")
+        write(file, "\n\n\n")
+        write(file, "#### EXTRAS ####\n")
 
         for extra in extras
             write(file, "$extra\n")
         end
 
-        write(file,"\n\n\n")
-        write(file,"#### RUN COMMAND ####\n")
-        write(file, "cd 'sample-%0$(digits)d' \$SLURM_ARRAY_TASK_ID\n")       ## Slurm array task not working
+        write(file, "\n\n\n")
+        write(file, "#### RUN COMMAND ####\n")
+        write(file, "cd 'sample-%0$(digits)d' \$SLURM_ARRAY_TASK_ID\n")
         write(file, "$run_command\n")
     end
 
-    p = pipeline(
-        Cmd(["sbatch --wait slurm_array.sh]"])
-    )
-    cd(() -> run(p), path)
-    # cd(() -> run(p))
+    p = pipeline(`sbatch --wait slurm_array.sh`)
+
+    cd(() -> run(p), dirpath)
 
     return nothing
 end

--- a/src/solvers/slurm.jl
+++ b/src/solvers/slurm.jl
@@ -59,7 +59,7 @@ function run_slurm_array(SI, m, n, path)
 
         write(file, "\n\n\n")
         write(file, "#### RUN COMMAND ####\n")
-        write(file, "cd 'sample-%0$(digits)d' \$SLURM_ARRAY_TASK_ID\n")
+        write(file, "cd sample-\$(printf %0$(digits)d \$SLURM_ARRAY_TASK_ID)\n")
         write(file, "$run_command\n")
     end
 

--- a/src/solvers/slurm.jl
+++ b/src/solvers/slurm.jl
@@ -2,20 +2,61 @@
 
 struct SlurmInterface
 
-    name::String
+    name::String        # Does nothing
     account::String
     nodes::Integer
     ntasks::Integer
     time::String
     partition::String
     extras::Vector{String}
-
+    batchsize::Integer
 end
 
-function make_input(SlurmInterface)
+function run_slurm_array(SI, m, n)
+    #slurm_array.sh
 
-end
+    binary = ExternalModel.solver.path
+    source = ExternalModel.solver.source
+    args = ExternalModel.solver.args
 
-function launch(SlurmInterface, ExternalModel )
+    run_command = !isempty(args) ? "$binary $args $source" : "$binary $source"
+
+    digits = ndigits(n)
+
+    fname = "slurm_array.sh"
+    dirpath = m.workdir
+    fpath = joinpath(dirpath, fname)
     
+    open(fpath, "w") do file
+        write(file, "#!/bin/bash -l")
+        write(file, "#SBATCH -A $(SI.account)")
+        write(file, "#SBATCH -p $(SI.partition)")
+        write(file, "#SBATCH -J UQ_array")
+        write(file, "#SBATCH --nodes=$(SI.nodes)")
+        write(file, "#SBATCH --ntasks=$(SI.ntasks)")
+        write(file, "#SBATCH --time=$(time)")
+        write(file, "#SBATCH --output=UncertaintyQuantification_%A-%a.out")
+        write(file, "#SBATCH --error=UncertaintyQuantification_%A-%a.err")
+        write(file, "#SBATCH --array=[1-$(n)]%$(SI.batch)")
+        write(file,"")
+        write(file,"")
+        write(file,"")
+        write(file,"")
+        write(file,"#### EXTRAS ####")
+
+        for extra in extras
+            write(file, extra)
+        end
+
+        write(file,"#### RUN COMMAND ####")
+        write(file, "cd 'sample-%0$(digits)d' $SLURM_ARRAY_TASK_ID")
+        write(file, "$run_command")
+    end
+
+    p = pipeline(
+        `sbatch --wait --array=[1-$(n)]%$(batch) slurm_array.sh`
+    )
+    cd(() -> run(p), folder)
+
+    return nothing
 end


### PR DESCRIPTION
Adds the functionality discussed in  #153

We can now pass a `SlurmInterface` type to external model, and any call to execute! will be submitted as a job array. 

```Julia
struct SlurmInterface
    name::String
    account::String
    partition::String
    nodes::Integer
    ntasks::Integer
    batchsize::Integer
    extras::Vector{String}
    time::String
end
```

Julia waits until job array competes. In a slurm environment, allows you also to run parallel sampling in parallel but with Julia running on a single node (e.g. from the login node). Submitted external model runs can now be as heavy as you like.

Also added
- slurm-opensees.jl example
- slurm-openmc.jl example 

Working, but some things to do:
- More constructors
- Docstrings
- Variable names check 
- Testing?