### PR TITLE
Fail demo action for untracked files

### DIFF
--- a/.github/workflows/DemoFilesUpToDate.yml
+++ b/.github/workflows/DemoFilesUpToDate.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Check demo files
         run: |
           julia --project=docs/ docs/literateDemo.jl;
-          if [[ $(git diff demo) ]] ; then exit 1; else exit 0; fi
+          if [[ `git status --porcelain` ]] ; then exit 1; else exit 0; fi


### PR DESCRIPTION
The current action will only fail if demo files are modified after running `Literate.jl`. This way the action will also fail for new untracked files.