### PR TITLE
Component-wise MCMC for subset simulation

### DIFF
--- a/src/simulations/subset.jl
+++ b/src/simulations/subset.jl
@@ -276,8 +276,8 @@ function nextlevelsamples(
 
         α_accept_per_dim = α .>= rand(size(α)...)
 
-        for d = 1:length(rvs)
-            chainsamples[α_accept_per_dim[:, d], rvs[d]] = ξ[α_accept_per_dim[:, d], d]
+        for (d, col) in enumerate(eachcol(α_accept_per_dim))
+            chainsamples[col, rvs[d]] = ξ[col, d]
         end
 
         α_MCMC[i] = mean(α_accept_per_dim)

--- a/src/simulations/subset.jl
+++ b/src/simulations/subset.jl
@@ -272,7 +272,7 @@ function nextlevelsamples(
         θ = Matrix{Float64}(chainsamples[:, rvs])
 
         ξ = θ + rand(sim.proposal, size(θ)...)
-        α = pdf(Φ, ξ) ./ pdf(Φ, θ)
+        α = pdf.(Φ, ξ) ./ pdf.(Φ, θ)
 
         α_accept_per_dim = α .>= rand(size(α)...)
 

--- a/src/simulations/subset.jl
+++ b/src/simulations/subset.jl
@@ -94,21 +94,28 @@ end
 
 Implementation of: Papaioannou, Iason, et al. "MCMC algorithms for subset simulation." Probabilistic Engineering Mechanics 41 (2015): 89-103
 
-Defines the properties of a Subset-∞ adaptive where `n` is the number of initial samples,
+Defines the properties of a Subset-∞ adaptive where `n` are the number of samples per level,
 `target` is the target probability of failure at each level, `levels` is the maximum number
-of levels and `λ` (λ = 1 recommended) is the initial scaling parameter and `Na` is the number of
-times to update `λ` per subset level (number of partitions of seeds). The initial variance of the proposal distribution is `λ`.
+of levels, `λ` (λ = 1 recommended) is the initial scaling parameter, and `Na` is the number simulations that will be run before `λ` 
+is updated. Note that Na must be a multiple of n * target: `mod(ceil(n * target), Na) == 0)`. The initial variance of the proposal distribution is `s`.
 
 
 Idea behind this algorithm is to adaptively select the correlation parameter of `s`
-at each intermediate level, by simulating a subset N_a of the chains
+at each intermediate level, by simulating a subset Na of the chains
 (which must be choosen without replacement at random) and modifying the acceptance rate towards the optiming
-α_star = 0.44
+αstar = 0.44
 
 # Constructors
 * `SubSetInfinityAdaptive(n::Integer, target::Float64, levels::Integer, Na::Integer)`   (default: λ = s = 1)
 * `SubSetInfinityAdaptive(n::Integer, target::Float64, levels::Integer, Na::Integer, λ::Real)` (λ = s)
 * `SubSetInfinityAdaptive(n::Integer, target::Float64, levels::Integer, Na::Integer, λ::Real, s::Real)`
+
+# Note
+The following constructors will run the same number of samples, but SubSetInfinityAdaptive will update `s` after each chain:
+
+* `SubSetInfinityAdaptive(400, 0.1, 10, 40)`
+* `SubSetInfinity(400, 0.1, 10, 0.5)`
+
 
 # Examples
 
@@ -250,8 +257,7 @@ function nextlevelsamples(
     number_of_chains = length(performance)
     samples_per_chain = Int64(floor(sim.n / number_of_chains))
 
-    d = length(rvs)
-    Φ = MvNormal(Diagonal(Matrix{Float64}(I, d, d)))
+    Φ = Normal(0, 1)
 
     α_MCMC = zeros(samples_per_chain)
     α_ss = zeros(samples_per_chain)
@@ -266,12 +272,17 @@ function nextlevelsamples(
         θ = Matrix{Float64}(chainsamples[:, rvs])
 
         ξ = θ + rand(sim.proposal, size(θ)...)
-        α = pdf(Φ, transpose(ξ)) ./ pdf(Φ, transpose(θ))
+        α = pdf(Φ, ξ) ./ pdf(Φ, θ)
 
-        α_accept = α .>= rand(size(α)...)
-        chainsamples[α_accept, rvs] = ξ[α_accept, :]
+        α_accept_per_dim = α .>= rand(size(α)...)
 
-        α_MCMC[i] = mean(α_accept)
+        for d = 1:length(rvs)
+            chainsamples[α_accept_per_dim[:, d], rvs[d]] = ξ[α_accept_per_dim[:, d], d]
+        end
+
+        α_MCMC[i] = mean(α_accept_per_dim)
+
+        α_accept = any(α_accept_per_dim, dims = 2)[:]
 
         to_physical_space!(inputs, chainsamples)
 

--- a/src/simulations/subset.jl
+++ b/src/simulations/subset.jl
@@ -257,7 +257,7 @@ function nextlevelsamples(
     number_of_chains = length(performance)
     samples_per_chain = Int64(floor(sim.n / number_of_chains))
 
-    Φ = Normal(0, 1)
+    Φ = Normal()
 
     α_MCMC = zeros(samples_per_chain)
     α_ss = zeros(samples_per_chain)


### PR DESCRIPTION
This PR changes the MCMC sampler in `SubSetSimulation` from usual Metropolis-Hastings, to component-wise MH. Dimensions are accepted independently, giving a better acceptance rate in higher dimensions.

closes #165 