### PR TITLE
Update and fix workflows

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -15,9 +15,9 @@ jobs:
         run: which julia
         continue-on-error: true
       - name: Install Julia, but only if it is not already available in the PATH
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
-          version: "1"
+          version: '1'
           arch: ${{ runner.arch }}
         if: steps.julia_in_path.outcome != 'success'
       - name: "Add the General registry via Git"

--- a/.github/workflows/DemoFilesUpToDate.yml
+++ b/.github/workflows/DemoFilesUpToDate.yml
@@ -13,10 +13,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
-          version: "1.9"
+          version: '1.10'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Check demo files

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v2
         with:
-          version: "1.9"
+          version: '1.10'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         julia-version:
           - '1.6'
-          - '1.9'
+          - '1.10'
         os:
           - 'ubuntu-latest'
           - 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-    tags: "*"
+    tags: '*'
   pull_request:
     branches:
       - master
@@ -15,12 +15,12 @@ jobs:
     strategy:
       matrix:
         julia-version:
-          - "1.6"
-          - "1.9"
+          - '1.6'
+          - '1.9'
         os:
-          - "ubuntu-latest"
-          - "windows-latest"
-          - "macOS-latest"
+          - 'ubuntu-latest'
+          - 'windows-latest'
+          - 'macOS-latest'
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - 'windows-latest'
           - 'macos-13'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         os:
           - 'ubuntu-latest'
           - 'windows-latest'
-          - 'macOS-latest'
+          - 'macos-13'
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - "macOS-latest"
     steps:
       - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
       - uses: julia-actions/cache@v1


### PR DESCRIPTION
The main issue was that `macos-latest` switched to `macos-14` where the `setup-julia` action wasn't working properly. By selecting `macos-13` the tests on Mac are working  again.

A few outdated actions are updated as well.