### PR TITLE
Drop julia 1.6 (lts) support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ on:
   push:
     branches:
       - master
-    tags: '*'
+    tags:
+      - "*"
   pull_request:
     branches:
       - master
@@ -15,12 +16,11 @@ jobs:
     strategy:
       matrix:
         julia-version:
-          - '1.6'
-          - '1.10'
+          - "1.10"
         os:
-          - 'ubuntu-latest'
-          - 'windows-latest'
-          - 'macos-13'
+          - "ubuntu-latest"
+          - "windows-latest"
+          - "macos-13"
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,9 @@
 name = "UncertaintyQuantification"
 uuid = "7183a548-a887-11e9-15ce-a56ab60bad7a"
-authors = ["Jasper Behrensdorf <behrensdorf@irz.uni-hannover.de>", "Ander Gray <ander.gray@liverpool.ac.uk>"]
+authors = [
+    "Jasper Behrensdorf <behrensdorf@irz.uni-hannover.de>",
+    "Ander Gray <ander.gray@liverpool.ac.uk>",
+]
 version = "0.9.0"
 
 [deps]
@@ -44,4 +47,4 @@ QuasiMonteCarlo = "0.3"
 Reexport = "0.2, 1.0"
 Statistics = "1"
 StatsBase = "0.33, 0.34"
-julia = "1.6, 1.7, 1.8"
+julia = "1.10"


### PR DESCRIPTION
This PR updates the compat entry for Julia to the latest stable version (1.10) and drops support for the lts release. The CI workflow is adapted accordingly.