### PR TITLE
Pass sns reference to gradient computation in standard normal space

### DIFF
--- a/src/inputs/inputs.jl
+++ b/src/inputs/inputs.jl
@@ -43,3 +43,16 @@ function count_rvs(inputs::Vector{<:UQInput})
 end
 
 mean(inputs::Vector{<:UQInput}) = mapreduce(mean, vcat, inputs)
+
+function sns_zero_point(inputs::AbstractVector{<:UQInput})
+    random_inputs = filter(i -> isa(i, RandomUQInput), inputs)
+    deterministic_inputs = filter(i -> isa(i, DeterministicUQInput), inputs)
+
+    sns = DataFrame(names(random_inputs) .=> zeros(count_rvs(random_inputs)))
+
+    if !isempty(deterministic_inputs)
+        sns = hcat(sns, sample(deterministic_inputs, 1))
+    end
+
+    return sns
+end

--- a/src/reliability/form.jl
+++ b/src/reliability/form.jl
@@ -30,9 +30,7 @@ function probability_of_failure(
 
     G = [models..., Model(performance, :performance)]
 
-    deterministic_inputs = filter(i -> isa(i, DeterministicUQInput), inputs)
-    parameters =
-        !isempty(deterministic_inputs) ? sample(deterministic_inputs, 1) : DataFrame()
+    sns = sample(inputs, 1)
 
     α = Vector{Float64}(undef, length(random_names))
     β::Float64 = 0.0
@@ -40,19 +38,16 @@ function probability_of_failure(
 
     # compute pf through HLRF algorithm
     for it in 1:(sim.n)
-        physical = DataFrame(random_names .=> y)
-        to_physical_space!(inputs, physical)
-        physical = hcat(physical, parameters)
+        sns[1, random_names] .= y
 
-        H = gradient_in_standard_normal_space(
-            G, inputs, physical, :performance; fdm=sim.fdm
-        )
+        H = gradient_in_standard_normal_space(G, inputs, sns, :performance; fdm=sim.fdm)
 
         H = map(n -> H[n], random_names)
 
-        evaluate!(G, physical)
+        to_physical_space!(inputs, sns)
+        evaluate!(G, sns)
 
-        h = physical[1, :performance]
+        h = sns[1, :performance]
 
         α = H ./ norm(H)
 

--- a/src/reliability/probabilityoffailure.jl
+++ b/src/reliability/probabilityoffailure.jl
@@ -33,7 +33,7 @@ function probability_of_failure(
         sim.direction = gradient_in_standard_normal_space(
             [models..., Model(x -> -1 * performance(x), :performance)],
             inputs,
-            DataFrame(names(inputs) .=> mean(inputs)),
+            sns_zero_point(inputs),
             :performance,
         )
     end

--- a/src/sensitivity/gradient.jl
+++ b/src/sensitivity/gradient.jl
@@ -35,7 +35,6 @@ function gradient_in_standard_normal_space(
     samples = copy(reference)
 
     random_names = names(filter(i -> isa(i, RandomUQInput), inputs))
-    to_standard_normal_space!(inputs, samples)
 
     function f(x)
         samples[:, random_names] .= x


### PR DESCRIPTION
This avoids unnecessary mappings back and forth and just makes a lot more sense.

Closes #177.