### PR TITLE
Fix design of experiment bounds

### DIFF
--- a/src/simulations/doe.jl
+++ b/src/simulations/doe.jl
@@ -63,10 +63,10 @@ end
 
 function bounds(r::RandomVariable, σ::Int)
     lb = minimum(r)
-    lb = isinf(lb) ? -std(r.dist) * σ : lb
+    lb = isinf(lb) ? mean(r.dist) -std(r.dist) * σ : lb
 
     ub = maximum(r)
-    ub = isinf(ub) ? std(r.dist) * σ : ub
+    ub = isinf(ub) ? mean(r.dist) +std(r.dist) * σ : ub
 
     return [lb ub]
 end

--- a/test/simulations/doe.jl
+++ b/test/simulations/doe.jl
@@ -314,8 +314,8 @@
         @test samples.x ≈ [-1, 0, 1, -1, 0, 1, -1, 0, 1] atol = 1e-12
         @test samples.y ≈ [0, 0, 0, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0] atol = 1e-12
 
-        x = RandomVariable(Normal(), :x)
-        y = RandomVariable(Exponential(), :y)
+        x = RandomVariable(Normal(1,1), :x)
+        y = RandomVariable(Exponential(2), :y)
 
         ff = FullFactorial([5, 5])
 
@@ -323,5 +323,8 @@
 
         @test all(isfinite.(samples.x))
         @test all(isfinite.(samples.y))
+
+        @test samples.x[1:5] ≈ [0.0, 0.5, 1.0, 1.5, 2.0] atol = 1e-12
+        @test samples.y[1:5:end] ≈ [0, 1, 2, 3, 4] atol = 1e-12
     end
 end


### PR DESCRIPTION
I have modified the doe test to catch the issue, since the old test was passing with the bug present. That happened because the test was using a zero mean normal to generate the doe points.
Then, the bug has been fixed by adding the mean to the bounds function.
Closes #205