### PR TITLE
Fix interval propagation for degenerate intervals

### DIFF
--- a/demo/reliability/linesampling.jl
+++ b/demo/reliability/linesampling.jl
@@ -18,18 +18,18 @@ x = RandomVariable.(Normal(), [:x1, :x2])
 y = Model(df -> df.x2 .+ 0.01 * df.x1 .^ 3 .+ sin.(df.x1), :y)
 
 # Limit-state function
-g(df) = 5 .- df.y
+g(df) = 3 .- df.y
 
 # Simulation
 numberlines = 200
 
 # Perform Line Sampling
-LS = LineSampling(numberlines, collect(0.5:0.5:10))
+LS = LineSampling(numberlines, collect(0.5:0.5:8))
 pf_ls, σ_pf_ls, samples_ls = probability_of_failure([y], g, x, LS)
 cov_ls = σ_pf_ls / pf_ls
 
 # Perform Advanced Line Sampling
-ALS = AdvancedLineSampling(numberlines, collect(0.5:0.5:10))
+ALS = AdvancedLineSampling(numberlines, collect(0.5:0.5:8))
 pf_als, σ_pf_als, samples_als = probability_of_failure([y], g, x, ALS)
 cov_als = σ_pf_als / pf_als
 
@@ -61,20 +61,20 @@ x_pbox = ProbabilityBox{Normal}.(Ref([mean, std]), [:x1, :x2])
 
 # Perform Line Sampling
 @time pf_ls_DL = probability_of_failure(
-    [y], g, x_pbox, DoubleLoop(LineSampling(numberlines, collect(0.5:0.5:10)))
+    [y], g, x_pbox, DoubleLoop(LineSampling(numberlines, collect(0.5:0.5:8)))
 )
-# @time pf_ls_RS, σ_pf_ls_RS, samples_ls_RS = probability_of_failure([y], g, x_pbox, RandomSlicing(LineSampling(numberlines, collect(0.5:0.5:10))))
+@time pf_ls_RS, σ_pf_ls_RS, samples_ls_RS = probability_of_failure([y], g, x_pbox, RandomSlicing(LineSampling(numberlines, collect(0.5:0.5:8))))
 
 # Perform Advanced Line Sampling
 @time pf_als_DL = probability_of_failure(
-    [y], g, x_pbox, DoubleLoop(AdvancedLineSampling(numberlines, collect(0.5:0.5:10)))
+    [y], g, x_pbox, DoubleLoop(AdvancedLineSampling(numberlines, collect(0.5:0.5:8)))
 )
-# @time pf_als_RS, σ_pf_als_RS, samples_als_RS = probability_of_failure([y], g, x_pbox, RandomSlicing(AdvancedLineSampling(numberlines, collect(0.5:0.5:10))))
+@time pf_als_RS, σ_pf_als_RS, samples_als_RS = probability_of_failure([y], g, x_pbox, RandomSlicing(AdvancedLineSampling(numberlines, collect(0.5:0.5:8))))
 
 println("Double Loop:")
 println("Line Sampling pf = [$(pf_ls_DL.lb), $(pf_ls_DL.ub)]")
 println("Advanced Line Sampling pf = [$(pf_als_DL.lb), $(pf_als_DL.ub)] \n")
 
-# println("Random Slicing:")
-# println("Line Sample pf = $pf_ls_RS")
-# println("Advanced Line Sample pf = $pf_als_RS")
+println("Random Slicing:")
+println("Line Sample pf = $pf_ls_RS")
+println("Advanced Line Sample pf = $pf_als_RS")

--- a/src/inputs/imprecise/interval.jl
+++ b/src/inputs/imprecise/interval.jl
@@ -42,3 +42,7 @@ function bounds(i::Interval)
 end
 
 Base.in(u, i::Interval) = i.lb <= u <= i.ub
+
+function isdegenerate(i::Interval)
+    return i.lb == i.ub
+end

--- a/src/inputs/imprecise/p-box.jl
+++ b/src/inputs/imprecise/p-box.jl
@@ -96,11 +96,7 @@ function quantile(pbox::ProbabilityBox{T}, u::Real) where {T<:UnivariateDistribu
     lb = minimum(quantiles)
     ub = maximum(quantiles)
 
-    if lb == ub
-        return lb
-    else
-        return Interval(lb, ub, pbox.name)
-    end
+    return Interval(lb, ub, pbox.name)
 end
 
 rand(pbox::ProbabilityBox, n::Integer=1) = quantile.(Ref(pbox), rand(n))

--- a/src/models/imprecise/propagation.jl
+++ b/src/models/imprecise/propagation.jl
@@ -12,9 +12,15 @@ function propagate_intervals!(
     output = isa(m, AbstractVector) ? m[end].name : m.name
 
     y = map(eachrow(df)) do row
-        lb = getproperty.(collect(row[interval_names]), :lb)
 
-        ub = getproperty.(collect(row[interval_names]), :ub)
+        degenerates = isdegenerate.(collect(row[interval_names]))
+        pure = .!degenerates
+
+        lb, ub = if any(degenerates)
+            getproperty.(collect(row[interval_names[pure]]), :lb), getproperty.(collect(row[interval_names[pure]]), :ub)
+        else
+            getproperty.(collect(row[interval_names]), :lb), getproperty.(collect(row[interval_names]), :ub)
+        end
 
         x0 = middle.(lb, ub)
 
@@ -24,8 +30,13 @@ function propagate_intervals!(
             select(DataFrame(row), Not(interval_names)),
         )
 
+        # set degenerate intervals to their precise value
+        if any(degenerates)
+            precise_df[1, interval_names[degenerates]] .= getproperty.(collect(row[interval_names[degenerates]]), :lb)
+        end
+
         function f(x)
-            precise_df[1, interval_names] .= x
+            precise_df[1, interval_names[pure]] .= x
 
             evaluate!(m, precise_df)
 

--- a/src/reliability/probabilityoffailure.jl
+++ b/src/reliability/probabilityoffailure.jl
@@ -31,7 +31,7 @@ function probability_of_failure(
 
     if isempty(sim.direction)
         sim.direction = gradient_in_standard_normal_space(
-            [models..., Model(x -> -1 * performance(x), :performance)],
+            [wrap(models)..., Model(x -> -1 * performance(x), :performance)],
             inputs,
             sns_zero_point(inputs),
             :performance,
@@ -69,7 +69,7 @@ function probability_of_failure(
 
     if isempty(sim.direction)
         sim.direction = gradient_in_standard_normal_space(
-            [models..., Model(x -> -1 * performance(x), :performance)],
+            [wrap(models)..., Model(x -> -1 * performance(x), :performance)],
             inputs,
             sns_zero_point(inputs),
             :performance,

--- a/src/simulations/linesampling.jl
+++ b/src/simulations/linesampling.jl
@@ -9,7 +9,7 @@ mutable struct LineSampling <: AbstractSimulation
         direction::NamedTuple=NamedTuple(),
     )
 
-    if maximum(points) > 8.0
+    if maximum(points) > 8.12
         error("LineSampling does not support lines longer than 8.12.")
     end
         return new(lines, points, direction)

--- a/src/simulations/linesampling.jl
+++ b/src/simulations/linesampling.jl
@@ -8,6 +8,10 @@ mutable struct LineSampling <: AbstractSimulation
         points::Vector{<:Real}=collect(0.5:0.5:5),
         direction::NamedTuple=NamedTuple(),
     )
+
+    if maximum(points) > 8.0
+        error("LineSampling does not support lines longer than 8.12.")
+    end
         return new(lines, points, direction)
     end
 end

--- a/test/inputs/imprecise/p-box.jl
+++ b/test/inputs/imprecise/p-box.jl
@@ -54,7 +54,7 @@
         @test a.ub == quantile(Normal(0, 0.1), 0.25)
 
         a = UncertaintyQuantification.quantile(p_box, 0.5)
-        @test a == 0.0
+        @test a == Interval(0.0, 0.0, :l)
 
         a = UncertaintyQuantification.quantile(p_box, 0.75)
         @test a.lb == quantile(Normal(0, 0.1), 0.75)

--- a/test/reliability/probabilityoffailure.jl
+++ b/test/reliability/probabilityoffailure.jl
@@ -28,6 +28,9 @@
     end
 
     @testset "Line sampling" begin
+
+        @test_throws ErrorException("LineSampling does not support lines longer than 8.12.") LineSampling(100, collect(0:0.1:10))
+
         # Englund and Rackwitz - A benchmark study on importance sampling techniques
         # in structural reliability (1993)
         # Example 1
@@ -43,7 +46,7 @@
             g, u, LineSampling(1, [0, 0.1])
         )
         @test_logs (:warn, "All samples for line 1 are inside the failure domain") probability_of_failure(
-            g, u, LineSampling(1, [10, 20])
+            g, u, LineSampling(1, collect(6:0.1:8))
         )
     end
 


### PR DESCRIPTION
Pboxes now always return intervals even if the bounds are equal.

In the propagation, I am checking for degenerate intervals to treat them as precise values. There might be a very rare edge case here, where all intervals are degraded and none are left to propagate. We'll get to that once we encounter this issue.

Closes #211.