### PR TITLE
Build vitepress documentation

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -16,10 +16,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1.10'
+          version: "1.10"
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
           GKSwstype: "100"
-        run: ./scripts/buildDocs.sh
+        run: ./scripts/buildVitePressDocs.sh

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -21,5 +21,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-          GKSwstype: "100"
         run: ./scripts/buildVitePressDocs.sh

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+build/
+node_modules/
+package-lock.json
+Manifest.toml

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,10 +3,11 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DisplayAs = "0b91fe84-8a4c-11e9-3e1d-67c38462b6d6"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
+DocumenterVitepress = "4710194d-e776-4893-9690-8d956a29c365"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 UncertaintyQuantification = "7183a548-a887-11e9-15ce-a56ab60bad7a"
 
 [compat]
-Documenter = "1.4.1"
+Documenter = "1.7.0"
 DocumenterCitations = "1.3.3"

--- a/docs/literate/bayesianupdating/inverse-eigenvalue.jl
+++ b/docs/literate/bayesianupdating/inverse-eigenvalue.jl
@@ -106,5 +106,5 @@ samples, evidence = bayesianupdating(likelihood, [λ1, λ2], tmcmc)
 scatter(samples.θ1, samples.θ2; lim=[0, 4], label="TMCMC", xlabel="θ1", ylabel="θ2")
 #md savefig("stiffness-samples.svg"); nothing # hide
 
-# ![](stiffness-samples.svg)
+# ![Resulting TMCMC](stiffness-samples.svg)
 #  A scatter plot of the resulting samples shows convergence to two distinct regions. Unlike the transitional Markov Chain Monte Carlo algorithm, the standard Metropolis-Hastings algorithm would have only identified one of the two regions.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,6 +9,8 @@ format = if !isempty(ARGS) && ARGS[1] == "vite"
     MarkdownVitepress(;
         repo="https://github.com/FriesischScott/UncertaintyQuantification.jl",
         deploy_url="https://friesischscott.github.io/UncertaintyQuantification.jl",
+        devbranch="master",
+        devurl="dev"
     )
 else
     Documenter.HTML(; prettyurls=get(ENV, "CI", nothing) == "true")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,6 @@ format = if !isempty(ARGS) && ARGS[1] == "vite"
 
     MarkdownVitepress(;
         repo="https://github.com/FriesischScott/UncertaintyQuantification.jl",
-        deploy_url="https://friesischscott.github.io/UncertaintyQuantification.jl",
         devbranch="master",
         devurl="dev"
     )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,6 +3,17 @@ using Documenter
 using DocumenterCitations
 using UncertaintyQuantification
 
+format = if !isempty(ARGS) && ARGS[1] == "vite"
+    using DocumenterVitepress
+
+    MarkdownVitepress(;
+        repo="https://github.com/FriesischScott/UncertaintyQuantification.jl",
+        deploy_url="https://friesischscott.github.io/UncertaintyQuantification.jl",
+    )
+else
+    Documenter.HTML(; prettyurls=get(ENV, "CI", nothing) == "true")
+end
+
 DocMeta.setdocmeta!(
     UncertaintyQuantification,
     :DocTestSetup,
@@ -14,7 +25,7 @@ bib = CitationBibliography(joinpath(@__DIR__, "references.bib"))
 makedocs(;
     modules=[UncertaintyQuantification],
     plugins=[bib],
-    format=Documenter.HTML(; prettyurls=get(ENV, "CI", nothing) == "true"),
+    format=format,
     sitename="UncertaintyQuantification.jl",
     authors="Jasper Behrensdorf and Ander Gray",
     pages=[

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,15 @@
+{
+  "scripts": {
+    "docs:dev": "vitepress dev build/.documenter",
+    "docs:build": "vitepress build build/.documenter",
+    "docs:preview": "vitepress preview build/.documenter"
+  },
+  "dependencies": {
+    "@shikijs/transformers": "^1.1.7",
+    "markdown-it": "^14.1.0",
+    "markdown-it-footnote": "^4.0.0",
+    "markdown-it-mathjax3": "^4.3.2",
+    "vitepress": "^1.1.4",
+    "vitepress-plugin-tabs": "^0.5.0"
+  }
+}

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -73,19 +73,6 @@
   doi       = {10.1061/(ASCE)0733-9399(2007)133:7(816)}
 }
 
-
-@article{chingTransitionalMarkovChain2007,
-  title     = {Transitional {{Markov Chain Monte Carlo Method}} for {{Bayesian Model Updating}}, {{Model Class Selection}}, and {{Model Averaging}}},
-  author    = {Ching, Jianye and Chen, Yi-Chu},
-  year      = {2007},
-  journal   = {Journal of Engineering Mechanics},
-  volume    = {133},
-  number    = {7},
-  pages     = {816--832},
-  publisher = {American Society of Civil Engineers},
-  doi       = {10.1061/(ASCE)0733-9399(2007)133:7(816)}
-}
-
 @article{dangEstimation2023,
   title      = {Estimation of Small Failure Probabilities by Partially {{Bayesian}} Active Learning Line Sampling: {{Theory}} and Algorithm},
   shorttitle = {Estimation of Small Failure Probabilities by Partially {{Bayesian}} Active Learning Line Sampling},
@@ -148,19 +135,6 @@
   doi     = {10.1093/biomet/57.1.97}
 }
 
-@article{hastingsMonteCarloSampling1970,
-  title   = {Monte {{Carlo}} Sampling Methods Using {{Markov}} Chains and Their Applications},
-  author  = {Hastings, W. K.},
-  year    = {1970},
-  journal = {Biometrika},
-  volume  = {57},
-  number  = {1},
-  pages   = {97--109},
-  issn    = {0006-3444},
-  doi     = {10.1093/biomet/57.1.97}
-}
-
-
 @book{joeDependenceModelingCopulas2015,
   title     = {Dependence {{Modeling}} with {{Copulas}}},
   author    = {Joe, Harry},
@@ -209,18 +183,6 @@
   pages   = {3--10},
   issn    = {01674730},
   doi     = {10.1016/0167-4730(89)90003-9}
-}
-
-@article{metropolisEquationStateCalculations1953,
-  title   = {Equation of {{State Calculations}} by {{Fast Computing Machines}}},
-  author  = {Metropolis, Nicholas and Rosenbluth, Arianna W. and Rosenbluth, Marshall N. and Teller, Augusta H. and Teller, Edward},
-  year    = {1953},
-  journal = {The Journal of Chemical Physics},
-  volume  = {21},
-  number  = {6},
-  pages   = {1087--1092},
-  issn    = {0021-9606},
-  doi     = {10.1063/1.1699114}
 }
 
 @article{metropolisEquationStateCalculations1953,
@@ -310,16 +272,6 @@
   pages   = {489--494},
   issn    = {0045-7949},
   doi     = {10.1016/0045-7949(78)90046-9}
-}
-
-@book{raiffaAppliedStatisticalDecision1961,
-  title     = {Applied {{Statistical Decision Theory}}},
-  author    = {Raiffa, Howard and Schaifer, Robert},
-  year      = {1961},
-  series    = {Studies in {{Managerial Economics}}},
-  publisher = {Division of Research, Graduate School of Business Adminitration, Harvard University},
-  location  = {Boston, MA},
-  pagetotal = {356}
 }
 
 @book{raiffaAppliedStatisticalDecision1961,

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -1,0 +1,48 @@
+import { defineConfig } from 'vitepress'
+import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs'
+import mathjax3 from "markdown-it-mathjax3";
+import footnote from "markdown-it-footnote";
+
+// https://vitepress.dev/reference/site-config
+export default defineConfig({
+  base: 'REPLACE_ME_DOCUMENTER_VITEPRESS',// TODO: replace this in makedocs!
+  title: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+  description: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+  lastUpdated: true,
+  cleanUrls: true,
+  outDir: 'REPLACE_ME_DOCUMENTER_VITEPRESS', // This is required for MarkdownVitepress to work correctly...
+  head: [['link', { rel: 'icon', href: 'REPLACE_ME_DOCUMENTER_VITEPRESS_FAVICON' }]],
+  ignoreDeadLinks: true,
+
+  markdown: {
+    math: true,
+    config(md) {
+      md.use(tabsMarkdownPlugin),
+      md.use(mathjax3),
+      md.use(footnote)
+    },
+    theme: {
+      light: "github-light",
+      dark: "github-dark"}
+  },
+  themeConfig: {
+    outline: 'deep',
+    logo: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+    search: {
+      provider: 'local',
+      options: {
+        detailedView: true
+      }
+    },
+    nav: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+    sidebar: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+    editLink: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+    socialLinks: [
+      { icon: 'github', link: 'REPLACE_ME_DOCUMENTER_VITEPRESS' }
+    ],
+    footer: {
+      message: 'Made with <a href="https://luxdl.github.io/DocumenterVitepress.jl/dev/" target="_blank"><strong>DocumenterVitepress.jl</strong></a><br>',
+      copyright: `© Copyright ${new Date().getUTCFullYear()}.`
+    }
+  }
+})

--- a/docs/src/.vitepress/theme/index.ts
+++ b/docs/src/.vitepress/theme/index.ts
@@ -1,0 +1,19 @@
+// .vitepress/theme/index.ts
+import { h } from 'vue'
+import type { Theme } from 'vitepress'
+import DefaultTheme from 'vitepress/theme'
+
+import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
+import './style.css'
+
+export default {
+  extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      // https://vitepress.dev/guide/extending-default-theme#layout-slots
+    })
+  },
+  enhanceApp({ app, router, siteData }) {
+    enhanceAppWithTabs(app)
+  }
+} satisfies Theme

--- a/docs/src/.vitepress/theme/style.css
+++ b/docs/src/.vitepress/theme/style.css
@@ -1,0 +1,266 @@
+/* Customize default theme styling by overriding CSS variables:
+https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/styles/vars.css
+ */
+
+  /* Layouts */
+
+/* 
+ :root {
+  --vp-layout-max-width: 1440px;
+} */
+
+.VPHero .clip {
+  white-space: pre;
+  max-width: 500px;
+}
+
+/* Fonts */
+
+@font-face {
+    font-family: JuliaMono-Regular;
+    src: url("https://cdn.jsdelivr.net/gh/cormullion/juliamono/webfonts/JuliaMono-Regular.woff2");
+}
+
+ :root {
+  /* Typography */
+  --vp-font-family-base: "Barlow", "Inter var experimental", "Inter var",
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+    Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+
+  /* Code Snippet font */
+  --vp-font-family-mono: JuliaMono-Regular, monospace;
+
+}
+
+/* 
+Disable contextual alternates (kind of like ligatures but different) in monospace, 
+which turns `/>` to an up arrow and `|>` (the Julia pipe symbol) to an up arrow as well.  
+This is pretty bad for Julia folks reading even though copy+paste retains the same text.
+*/
+/* Target elements with class 'mono' */
+.mono-no-substitutions {
+  font-family: "JuliaMono-Light", monospace;
+  font-feature-settings: "calt" off;
+}
+
+/* Alternatively, you can use the following if you prefer: */
+.mono-no-substitutions-alt {
+  font-family: "JuliaMono-Light", monospace;
+  font-variant-ligatures: none;
+}
+
+/* If you want to apply this globally to all monospace text: */
+pre, code {
+  font-family: "JuliaMono-Light", monospace;
+  font-feature-settings: "calt" off;
+}
+
+/* Colors */
+
+:root {
+  --julia-blue: #4063D8;
+  --julia-purple: #9558B2;
+  --julia-red: #CB3C33;
+  --julia-green: #389826;
+
+  --vp-c-brand: #389826;
+  --vp-c-brand-light: #3dd027;
+  --vp-c-brand-lighter: #9499ff;
+  --vp-c-brand-lightest: #bcc0ff;
+  --vp-c-brand-dark: #535bf2;
+  --vp-c-brand-darker: #454ce1;
+  --vp-c-brand-dimm: #212425;
+}
+
+ /* Component: Button */
+
+:root {
+  --vp-button-brand-border: var(--vp-c-brand-light);
+  --vp-button-brand-text: var(--vp-c-white);
+  --vp-button-brand-bg: var(--vp-c-brand);
+  --vp-button-brand-hover-border: var(--vp-c-brand-light);
+  --vp-button-brand-hover-text: var(--vp-c-white);
+  --vp-button-brand-hover-bg: var(--vp-c-brand-light);
+  --vp-button-brand-active-border: var(--vp-c-brand-light);
+  --vp-button-brand-active-text: var(--vp-c-white);
+  --vp-button-brand-active-bg: var(--vp-button-brand-bg);
+}
+
+/* Component: Home */
+
+:root {
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: -webkit-linear-gradient(
+    120deg,
+    #9558B2 30%,
+    #CB3C33
+  );
+
+  --vp-home-hero-image-background-image: linear-gradient(
+    -45deg,
+    #9558B2 30%,
+    #389826 30%,
+    #CB3C33 
+  );
+  --vp-home-hero-image-filter: blur(40px);
+}
+
+@media (min-width: 640px) {
+  :root {
+    --vp-home-hero-image-filter: blur(56px);
+  }
+}
+
+@media (min-width: 960px) {
+  :root {
+    --vp-home-hero-image-filter: blur(72px);
+  }
+}
+
+/* Component: Custom Block */
+
+:root.dark {
+  --vp-custom-block-tip-border: var(--vp-c-brand);
+  --vp-custom-block-tip-text: var(--vp-c-brand-lightest);
+  --vp-custom-block-tip-bg: var(--vp-c-brand-dimm);
+
+    /* // Tweak the color palette for blacks and dark grays */
+    --vp-c-black: hsl(220 20% 9%);
+    --vp-c-black-pure: hsl(220, 24%, 4%);
+    --vp-c-black-soft: hsl(220 16% 13%);
+    --vp-c-black-mute: hsl(220 14% 17%);
+    --vp-c-gray: hsl(220 8% 56%);
+    --vp-c-gray-dark-1: hsl(220 10% 39%);
+    --vp-c-gray-dark-2: hsl(220 12% 28%);
+    --vp-c-gray-dark-3: hsl(220 12% 23%);
+    --vp-c-gray-dark-4: hsl(220 14% 17%);
+    --vp-c-gray-dark-5: hsl(220 16% 13%);
+  
+    /* // Backgrounds */
+    /* --vp-c-bg: hsl(240, 2%, 11%); */
+    --vp-custom-block-info-bg: hsl(220 14% 17%);
+    /* --vp-c-gutter: hsl(220 20% 9%);
+
+    --vp-c-bg-alt: hsl(220 20% 9%);
+    --vp-c-bg-soft: hsl(220 14% 17%);
+    --vp-c-bg-mute: hsl(220 12% 23%);
+     */
+}
+
+ /* Component: Algolia */
+
+.DocSearch {
+  --docsearch-primary-color: var(--vp-c-brand) !important;
+}
+
+/* Component: MathJax */
+
+mjx-container > svg {
+  display: block;
+  margin: auto;
+}
+
+mjx-container {
+  padding: 0.5rem 0;
+}
+
+mjx-container {
+  display: inline;
+  margin: auto 2px -2px;
+}
+
+mjx-container > svg {
+  margin: auto;
+  display: inline-block;
+}
+
+/**
+ * Colors links
+ * -------------------------------------------------------------------------- */
+
+ :root {
+  --vp-c-brand-1: #CB3C33;
+  --vp-c-brand-2: #CB3C33;
+  --vp-c-brand-3: #CB3C33;
+  --vp-c-sponsor: #ca2971;
+  --vitest-c-sponsor-hover: #c13071;
+}
+
+.dark {
+  --vp-c-brand-1: #91dd33;
+  --vp-c-brand-2: #91dd33;
+  --vp-c-brand-3: #91dd33;
+  --vp-c-sponsor: #91dd33;
+  --vitest-c-sponsor-hover: #e51370;
+}
+
+/**
+ * Change images from light to dark theme
+ * -------------------------------------------------------------------------- */
+
+ :root:not(.dark) .dark-only {
+  display: none;
+}
+
+:root:is(.dark) .light-only {
+  display: none;
+}
+
+/* https://bddxg.top/article/note/vitepress优化/一些细节上的优化.html#文档页面调整-加宽 */
+
+.VPDoc.has-aside .content-container {
+  max-width: 100% !important;
+}
+.aside {
+  max-width: 200px !important;
+  padding-left: 0 !important;
+}
+.VPDoc {
+  padding-top: 15px !important;
+  padding-left: 5px !important;
+
+}
+/* This one does the right menu */
+
+.VPDocOutlineItem li {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 200px;
+}
+
+.VPNavBar .title {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+@media (max-width: 960px) {
+  .VPDoc {
+    padding-left: 25px !important;  
+  }
+}
+
+/* This one does the left menu */
+
+/* .VPSidebarItem .VPLink p {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 200px;
+} */
+
+
+/* Component: Docstring Custom Block */
+
+.jldocstring.custom-block {
+    border: 1px solid var(--vp-c-gray-2);
+    color: var(--vp-c-text-1)
+}
+
+.jldocstring.custom-block summary {
+    font-weight: 700;
+    cursor: pointer;
+    user-select: none;
+    margin: 0 0 8px;
+}

--- a/docs/src/manual/bayesianupdating.md
+++ b/docs/src/manual/bayesianupdating.md
@@ -222,6 +222,6 @@ tmcmc_samples, S = bayesianupdating(loglikelihood, tmcmc)
 
 ## Bayesian calibration of computer simulations
 
-*UncertaintyQuantification.jl* allows for complex computer models to be included in the Bayesian updating procedure, if for example one wishes to infer unknown model parameters from experimental data of model outputs. Several models can be evaluated in order to compute the likelihood function, by passing a vector of [`UQModel`](@ref)s to the [`bayesianupdating`](@ref) method. These will be executed before the likelihood is evaluated and models outputs will be available in the `DataFrame` inside the likelihood function. There is no restriction on the type of [`UQModel`](@ref) used. For example, it is possible to use an [`ExternalModel`](@ref) and call an external solver.
+*UncertaintyQuantification.jl* allows for complex computer models to be included in the Bayesian updating procedure, if for example one wishes to infer unknown model parameters from experimental data of model outputs. Several models can be evaluated in order to compute the likelihood function, by passing a vector of [`UQModel`](@ref)s to the [`bayesianupdating`](@ref) method. These will be executed before the likelihood is evaluated and models outputs will be available in the `DataFrame` inside the likelihood function. There is no restriction on the type of [`UQModel`](@ref) used. For example, it is possible to use an `ExternalModel` and call an external solver.
 
 For a complete example refer to the [Inverse eigenvalue problem](@ref).

--- a/docs/src/manual/gettingstarted.md
+++ b/docs/src/manual/gettingstarted.md
@@ -142,7 +142,7 @@ After formatting and injecting the values into the source file, it would look si
 nDMaterial ElasticIsotropic 1 9.99813819e+02 0.25 3.03176259e+00
 ```
 
-Now that the values are injected into the source files, the next step is to extract the desired output quantities. This is done using an `Extractor`. The `Extractor` is designed similarly to the `Model` in that it takes a `Function` and a `Symbol` as its parameters. However, where a `DataFrame` is passed to the `Model`, the working directoy for the currently evaluated sample is passed to the function of the `Extractor`. The user defined function must then extract the required values from the file and return them. Here, we make use of the *DelimitedFiles* module to extract the maximum absolute displacement from the output file that *OpenSees* generated.
+Now that the values are injected into the source files, the next step is to extract the desired output quantities. This is done using an `Extractor`. The `Extractor` is designed similarly to the `Model` in that it takes a `Function` and a `Symbol` as its parameters. However, where a `DataFrame` is passed to the `Model`, the working directory for the currently evaluated sample is passed to the function of the `Extractor`. The user defined function must then extract the required values from the file and return them. Here, we make use of the *DelimitedFiles* module to extract the maximum absolute displacement from the output file that *OpenSees* generated.
 
 ```julia
 disp = Extractor(base -> begin

--- a/docs/src/manual/gettingstarted.md
+++ b/docs/src/manual/gettingstarted.md
@@ -122,7 +122,9 @@ extrafiles = String[]
 workdir = joinpath(pwd(), "supported-beam")
 ```
 
-Next, we must define where to inject values from the random variables and parameters into the input files. For this, we make use of the *Mustache.jl* and *Format.jl* modules. The values in the source file must be replaced by triple curly bracket expressions of the form `{{{ :x }}}`,  where `:x` is the identifier of the `RandomVariable` or `Parameter` to be injected. For example, to inject the Young's modulus and density of an elastic isotropic material in *OpenSees*, one could write the following.
+```@raw html
+Next, we must define where to inject values from the random variables and parameters into the input files. For this, we make use of the *Mustache.jl* and *Format.jl* modules. The values in the source file must be replaced by triple curly bracket expressions of the form <code v-pre>{{{ :x }}}</code>,  where `:x` is the identifier of the `RandomVariable` or `Parameter` to be injected. For example, to inject the Young's modulus and density of an elastic isotropic material in *OpenSees*, one could write the following.
+```
 
 ```tcl
 nDMaterial ElasticIsotropic 1 {{{ :E }}} 0.25 {{{ :rho }}}

--- a/docs/src/manual/introduction.md
+++ b/docs/src/manual/introduction.md
@@ -4,9 +4,8 @@
 
 The definition of *uncertainty* follows from the absence of *certainty* describing a state of absolute knowledge where everything there is to know about a process is known [nikolaidisTypesUncertaintyDesign2004](@cite). This however is a theoretical and unachievable state in which deterministic models would be sufficient for the analysis of engineering systems. In reality, there is always a gap between certainty and the current state of knowledge resulting in *uncertainty*.
 
-| ![Characterization of uncertainties](../assets/uncertainty.svg) |
-| :--: |
-| *Characterization of reducible and irreducible uncertainties. Adapted from [aughenbaughValueUsingImprecise2005](@cite)*. |
+![Characterization of uncertainties](../assets/uncertainty.svg)
+*Characterization of reducible and irreducible uncertainties. Adapted from [aughenbaughValueUsingImprecise2005](@cite)*.
 
 Although a topic of ongoing debate and revision [aughenbaughValueUsingImprecise2005](@cite), it is largely accepted that uncertainty can be broadly classified into two types, *aleatory* and *epistemic* uncertainty [kiureghianAleatoryEpistemicDoes2009](@cite). The first type, *aleatory* uncertainties, are also called *irreducible* uncertainties or *variability* and describe the inherent randomness of a process. This could, for example, be variability in material properties, degradation of components, or varying external forces such as wind loads or earthquakes. Some researchers debate the existence of aleatory uncertainty under the assumption that if a process was fully understood it would no longer be random. Epistemic uncertainty is the uncertainty resulting from a lack of knowledge or vagueness and is also called *reducible* uncertainty, as it can be reduced through the collection of additional data and information. If both types of uncertainties occur together this is sometimes called *hybrid* or *mixed* uncertainty, and can be modelled using imprecise probability.
 

--- a/docs/src/manual/parallelisation.md
+++ b/docs/src/manual/parallelisation.md
@@ -30,7 +30,7 @@ evaluate!(m, samples)
 rmprocs(workers()) # release the local workers
 ```
 
-It is important to note, that the [`ParallelModel`](@ref) requires some overhead to distribute the function calls to the workers. Therefore it performs significantly slower than the standard [`Model`](@ref) with vectorized operations for a simple function as in this example. The method of executing a model in parallel presented above also applies to the [`ExternalModel`](@ref).
+It is important to note, that the [`ParallelModel`](@ref) requires some overhead to distribute the function calls to the workers. Therefore it performs significantly slower than the standard [`Model`](@ref) with vectorized operations for a simple function as in this example. The method of executing a model in parallel presented above also applies to the `ExternalModel`.
 
 !!! note
     For heavier external models the use of parallel compute clusters through the [`SlurmInterface`](@ref) is recommended. See [High Performance Computing](hpc.md).

--- a/scripts/buildDocs.sh
+++ b/scripts/buildDocs.sh
@@ -1,6 +1,8 @@
 
 #! /bin/bash
 
+export GKSwstype=100
+
 julia --project=docs/ -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.update()'
 
 julia --project=docs/ docs/literateDocs.jl

--- a/scripts/buildVitePressDocs.ps1
+++ b/scripts/buildVitePressDocs.ps1
@@ -3,4 +3,4 @@ julia --project=docs/ -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.update()'
 
 julia --project=docs/ docs/literateDocs.jl
 
-julia --project=docs/ docs/make.jl
+julia --project=docs/ docs/make.jl vite

--- a/scripts/buildVitePressDocs.sh
+++ b/scripts/buildVitePressDocs.sh
@@ -1,6 +1,8 @@
 
 #! /bin/bash
 
+export GKSwstype=100
+
 julia --project=docs/ -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.update()'
 
 julia --project=docs/ docs/literateDocs.jl

--- a/scripts/buildVitePressDocs.sh
+++ b/scripts/buildVitePressDocs.sh
@@ -1,6 +1,8 @@
 
+#! /bin/bash
+
 julia --project=docs/ -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.update()'
 
 julia --project=docs/ docs/literateDocs.jl
 
-julia --project=docs/ docs/make.jl
+julia --project=docs/ docs/make.jl vite


### PR DESCRIPTION
There were a few workarounds necessary here and there, but I'm confident that it works now.

The build is triggered by passing `vite` as an argument to `make.jl`.  I've added extra scripts `buildVitePressDocs` for convenience.

Closes #221 