### PR TITLE
Fix broadcasting of inputs

### DIFF
--- a/src/inputs/inputs.jl
+++ b/src/inputs/inputs.jl
@@ -56,3 +56,5 @@ function sns_zero_point(inputs::AbstractVector{<:UQInput})
 
     return sns
 end
+
+Base.broadcastable(i::T) where {T<:UQInput} = Ref(i)

--- a/test/inputs/inputs.jl
+++ b/test/inputs/inputs.jl
@@ -31,4 +31,10 @@ inputs = [pi, jd, z]
     @testset "count_rvs" begin
         @test count_rvs(inputs) == 3
     end
+
+    @testset "broadcasting" begin
+        x = RandomVariable(Normal(), :x)
+        u = rand(10)
+        @test pdf.(x.dist, u) == pdf.(x, u)
+    end
 end


### PR DESCRIPTION
By overloading `Base.broadcastable` all subtypes of `UQInput` can now properly use broadcasting.