### PR TITLE
Throw error for non consistent Beta mean parameter

### DIFF
--- a/src/inputs/randomvariables/distributionparameters.jl
+++ b/src/inputs/randomvariables/distributionparameters.jl
@@ -1,7 +1,12 @@
 function distribution_parameters(mean::Real, std::Real, _::Type{Distributions.Beta})
-    α = ((1 - mean) / std^2 - (1 / mean)) * mean^2
-    β = α * ((1 / mean) - 1)
-
+    if 0 < mean < 1
+        α = ((1 - mean) / std^2 - (1 / mean)) * mean^2
+        β = α * ((1 / mean) - 1)
+    else
+        error(
+            "provided mean value $mean is not compatible with Beta distribution support: (0; 1)",
+        )
+    end
     return α, β
 end
 

--- a/test/inputs/randomvariables/distributionparameters.jl
+++ b/test/inputs/randomvariables/distributionparameters.jl
@@ -4,6 +4,10 @@
     μ = mean(d)
     σ = std(d)
     @test [distribution_parameters(μ, σ, Beta)...] ≈ [0.5, 0.5]
+    μ = -0.1
+    @test_throws ErrorException(
+        "provided mean value -0.1 is not compatible with Beta distribution support: (0; 1)"
+    ) distribution_parameters(μ, σ, Beta)
 
     # Gamma
     d = Gamma(3.0, 2.0)


### PR DESCRIPTION
Throw an error when a value not in ```(0, 1)``` is provided to ```distribution_parameter(mean, sigma, Beta)```