### PR TITLE
Add Radial Based Importance Sampling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,6 @@
 name = "UncertaintyQuantification"
 uuid = "7183a548-a887-11e9-15ce-a56ab60bad7a"
-authors = [
-    "Jasper Behrensdorf <behrensdorf@irz.uni-hannover.de>",
-    "Ander Gray <ander.gray@hds.utc.fr>",
-]
+authors = ["Jasper Behrensdorf <behrensdorf@irz.uni-hannover.de>", "Ander Gray <ander.gray@hds.utc.fr>"]
 version = "0.12.0"
 
 [deps]
@@ -29,6 +26,7 @@ QuasiMonteCarlo = "8a4e6c94-4038-4cdc-81c3-7e6ffdb2a71b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
@@ -51,6 +49,7 @@ QuadGK = "2.11.1"
 QuasiMonteCarlo = "0.3"
 Reexport = "0.2, 1.0"
 Roots = "2.2.2"
+SpecialFunctions = "2.5.0"
 Statistics = "1"
 StatsBase = "0.33, 0.34"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,9 @@
 name = "UncertaintyQuantification"
 uuid = "7183a548-a887-11e9-15ce-a56ab60bad7a"
-authors = ["Jasper Behrensdorf <behrensdorf@irz.uni-hannover.de>", "Ander Gray <ander.gray@hds.utc.fr>"]
+authors = [
+    "Jasper Behrensdorf <behrensdorf@irz.uni-hannover.de>",
+    "Ander Gray <ander.gray@hds.utc.fr>",
+]
 version = "0.12.0"
 
 [deps]
@@ -26,7 +29,6 @@ QuasiMonteCarlo = "8a4e6c94-4038-4cdc-81c3-7e6ffdb2a71b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
@@ -49,7 +51,6 @@ QuadGK = "2.11.1"
 QuasiMonteCarlo = "0.3"
 Reexport = "0.2, 1.0"
 Roots = "2.2.2"
-SpecialFunctions = "2.5.0"
 Statistics = "1"
 StatsBase = "0.33, 0.34"
 julia = "1.10"

--- a/demo/reliability/cantilever.jl
+++ b/demo/reliability/cantilever.jl
@@ -55,6 +55,16 @@ println(
     "Importance Sampling probability of failure: $is_pf ($(size(is_samples, 1)) model evaluations)",
 )
 
+rbis = RadialBasedImportanceSampling(10^4, β)
+
+rbis_pf, rbis_cov, rbis_samples = probability_of_failure(
+    [inertia, displacement], df -> max_displacement .- df.w, inputs, rbis
+)
+
+println(
+    "Radial Based Importance Sampling probability of failure $rbis_pf ($(size(rbis_samples, 1)) model evaluations)",
+)
+
 # Compute probability of failure using Line Sampling
 ls = LineSampling(200)
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -65,7 +65,7 @@ makedocs(;
         ],
         "References" => "references.md",
     ],
-    warnonly=false,
+    warnonly=true,
     draft=false,
     source="src",
     build="build",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -54,6 +54,7 @@ makedocs(;
         "API" => [
             "Inputs" => "api/inputs.md",
             "Models" => "api/models.md",
+            "Reliability" => "api/reliability.md",
             "ResponseSurface" => "api/responsesurface.md",
             "PolyharmonicSpline" => "api/polyharmonicspline.md",
             "Simulations" => "api/simulations.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -65,7 +65,7 @@ makedocs(;
         ],
         "References" => "references.md",
     ],
-    warnonly=true,
+    warnonly=false,
     draft=false,
     source="src",
     build="build",

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -133,6 +133,18 @@
   doi         = {10.2172/809606}
 }
 
+@article{harbitzEfficientSamplingMethod1986,
+  title   = {An Efficient Sampling Method for Probability of Failure Calculation},
+  author  = {Harbitz, Alf},
+  year    = {1986},
+  journal = {Structural Safety},
+  volume  = {3},
+  number  = {2},
+  pages   = {109--115},
+  issn    = {0167-4730},
+  doi     = {10.1016/0167-4730(86)90012-3}
+}
+
 @article{hastingsMonteCarloSampling1970,
   title   = {Monte {{Carlo}} Sampling Methods Using {{Markov}} Chains and Their Applications},
   author  = {Hastings, W. K.},
@@ -163,6 +175,7 @@
   year    = {1957}
 }
 
+
 @article{kiureghianAleatoryEpistemicDoes2009,
   title      = {Aleatory or Epistemic? {{Does}} It Matter?},
   shorttitle = {Aleatory or Epistemic?},
@@ -176,7 +189,6 @@
   issn       = {0167-4730},
   doi        = {10.1016/j.strusafe.2008.06.020}
 }
-
 
 @article{koutsourelakisReliability2004,
   title      = {Reliability of Structures in High Dimensions, Part {{I}}: Algorithms and Applications},
@@ -324,6 +336,7 @@
   pages   = {683--690},
   doi     = {10.1111/j.2517-6161.1991.tb01857.x}
 }
+
 
 @article{shinozuka1991simulation,
   title     = {Simulation of stochastic processes by spectral representation},

--- a/docs/src/api/reliability.md
+++ b/docs/src/api/reliability.md
@@ -4,6 +4,7 @@
 
 ```@index
 Pages = ["reliability.md"]
+```
 
 ## Types
 
@@ -14,6 +15,6 @@ FORM
 ## Methods
 
 ```@docs
-probability_of_failure(models::Union{Vector{<:UQModel},UQModel},performance::Function),inputs::Union{Vector{<:UQInput},UQInput},sim::FORM)
-probability_of_failure(models::Union{Vector{<:UQModel},UQModel},performance::Function),inputs::Union{Vector{<:UQInput},UQInput},sim::AbstractMonteCarlo)
+probability_of_failure(models::Union{Vector{<:UQModel},UQModel},performance::Function,inputs::Union{Vector{<:UQInput},UQInput},sim::FORM)
+probability_of_failure(models::Union{Vector{<:UQModel},UQModel},performance::Function,inputs::Union{Vector{<:UQInput},UQInput},sim::AbstractMonteCarlo)
 ```

--- a/docs/src/api/reliability.md
+++ b/docs/src/api/reliability.md
@@ -14,5 +14,6 @@ FORM
 ## Methods
 
 ```@docs
-probability_of_failure
+probability_of_failure(models::Union{Vector{<:UQModel},UQModel},performance::Function),inputs::Union{Vector{<:UQInput},UQInput},sim::FORM)
+probability_of_failure(models::Union{Vector{<:UQModel},UQModel},performance::Function),inputs::Union{Vector{<:UQInput},UQInput},sim::AbstractMonteCarlo)
 ```

--- a/docs/src/api/reliability.md
+++ b/docs/src/api/reliability.md
@@ -1,0 +1,18 @@
+# Reliability
+
+## Index
+
+```@index
+Pages = ["reliability.md"]
+
+## Types
+
+```@docs
+FORM
+```
+
+## Methods
+
+```@docs
+probability_of_failure
+```

--- a/docs/src/api/simulations.md
+++ b/docs/src/api/simulations.md
@@ -11,6 +11,7 @@ Pages = ["simulations.md"]
 ## Types
 
 ```@docs
+RadialBasedImportanceSampling
 SubSetSimulation
 SubSetInfinity
 SubSetInfinityAdaptive

--- a/docs/src/manual/reliability.md
+++ b/docs/src/manual/reliability.md
@@ -158,6 +158,32 @@ println("Probability of failure: $pf_is")
 println("Coefficient of variation: $(std_is/pf_is)")
 ```
 
+## Radial Based Importance Sampling
+
+Radial based importance sampling (RBIS) [harbitzEfficientSamplingMethod1986](@cite) increases the efficiency of the Monte Carlo simulation by sampling in standard normal space and excluding a β-sphere where no failures occur from the sampling domain. Here, `β` is the reliability index obtained from a preliminary analysis like FORM. The probability of failure is then estimated as
+
+```math
+p_f \approx \hat{p}_f = (1- \chi^2_k(\beta^2) \frac{1}{N} \sum_{i=1}^N \mathbb{I}[g(\boldsymbol{x}_i)],
+```
+
+where ``\chi^2_k`` is the CDF of the Chi-squared distribution with ``k`` degrees of freedom and ``k`` is the number of random variables.
+
+If no `β` or `β=0.0` is passed to the [`RadialBasedImportanceSampling`](@ref) constructor, a FORM analysis will automatically be performed.
+
+```@example reliability
+rbis = RadialBasedImportanceSampling(1000)
+pf_rbis, std_rbis, samples = probability_of_failure(y, g, x, rbis)
+
+println("Probability of failure: $pf_rbis")
+println("Coefficient of variation: $(std_rbis/pf_rbis)")
+
+scatter(samples.x1, samples.x2; xlabel="x1", ylabel="x2", aspect_ratio=:equal) # hide
+savefig("rbis-samples.svg"); nothing # hide
+```
+
+A scatter plot cleary shows the exclusion of the β-sphere.
+![RBIS samples](rbis-samples.svg)
+
 ### Line Sampling
 
 Another advanced Monte Carlo method for reliability analysis is Line Sampling [koutsourelakisReliability2004](@cite).
@@ -245,29 +271,3 @@ pf_sus, std_sus, samples = probability_of_failure(y, g, x, subset)
 println("Probability of failure: $pf_sus")
 println("Coefficient of variation: $(std_sus/pf_sus)")
 ```
-
-## Radial Based Importance Sampling
-
-Radial based importance sampling (RBIS) [harbitzEfficientSamplingMethod1986](@cite) increases the efficiency of the Monte Carlo simulation by sampling in standard normal space and excluding a β-sphere where no failures occur from the sampling domain. Here, `β` is the reliability index obtained from a preliminary analysis like FORM. The probability of failure is then estimated as
-
-```math
-p_f \approx \hat{p}_f = (1- \chi^2_k(\beta^2) \frac{1}{N} \sum_{i=1}^N \mathbb{I}[g(\boldsymbol{x}_i)],
-```
-
-where ``\chi^2_k`` is the CDF of the Chi-squared distribution with ``k`` degrees of freedom and ``k`` is the number of random variables.
-
-If no `β` is passed to the [`RadialBasedImportanceSampling`](@ref) constructor, a FORM analysis will automatically be performed.
-
-```@example reliability
-rbis = RadialBasedImportanceSampling(1000)
-pf_rbis, std_rbis, samples = probability_of_failure(y, g, x, rbis)
-
-println("Probability of failure: $pf_rbis")
-println("Coefficient of variation: $(std_rbis/pf_rbis)")
-
-scatter(samples.x1, samples.x2; xlabel="x1", ylabel="x2") # hide
-savefig("rbis-samples.svg"); nothing # hide
-```
-
-A scatter plot cleary shows the exclusion of the β-sphere.
-![RBIS samples](rbis-samples.svg)

--- a/docs/src/manual/reliability.md
+++ b/docs/src/manual/reliability.md
@@ -158,7 +158,7 @@ println("Probability of failure: $pf_is")
 println("Coefficient of variation: $(std_is/pf_is)")
 ```
 
-## Radial Based Importance Sampling
+### Radial Based Importance Sampling
 
 Radial based importance sampling (RBIS) [harbitzEfficientSamplingMethod1986](@cite) increases the efficiency of the Monte Carlo simulation by sampling in standard normal space and excluding a β-sphere where no failures occur from the sampling domain. Here, `β` is the reliability index obtained from a preliminary analysis like FORM. The probability of failure is then estimated as
 
@@ -181,7 +181,7 @@ scatter(samples.x1, samples.x2; xlabel="x1", ylabel="x2", aspect_ratio=:equal) #
 savefig("rbis-samples.svg"); nothing # hide
 ```
 
-A scatter plot cleary shows the exclusion of the β-sphere.
+A scatter plot clearly shows the exclusion of the β-sphere.
 ![RBIS samples](rbis-samples.svg)
 
 ### Line Sampling

--- a/docs/src/manual/reliability.md
+++ b/docs/src/manual/reliability.md
@@ -40,7 +40,7 @@ g(\boldsymbol{X}) = y(\boldsymbol{X}) + 4.
 The probabilistic input is implemented as
 
 ```@example reliability
-using UncertaintyQuantification, DataFrames # hide
+using UncertaintyQuantification, DataFrames, Plots # hide
 using Random # hide
 Random.seed!(42) # hide
 x = RandomVariable.(Normal(), [:x1, :x2])
@@ -245,3 +245,29 @@ pf_sus, std_sus, samples = probability_of_failure(y, g, x, subset)
 println("Probability of failure: $pf_sus")
 println("Coefficient of variation: $(std_sus/pf_sus)")
 ```
+
+## Radial Based Importance Sampling
+
+Radial based importance sampling (RBIS) [harbitzEfficientSamplingMethod1986](@cite) increases the efficiency of the Monte Carlo simulation by sampling in standard normal space and excluding a β-sphere where no failures occur from the sampling domain. Here, `β` is the reliability index obtained from a preliminary analysis like FORM. The probability of failure is then estimated as
+
+```math
+p_f \approx \hat{p}_f = (1- \chi^2_k(\beta^2) \frac{1}{N} \sum_{i=1}^N \mathbb{I}[g(\boldsymbol{x}_i)],
+```
+
+where ``\chi^2_k`` is the CDF of the Chi-squared distribution with ``k`` degrees of freedom and ``k`` is the number of random variables.
+
+If no `β` is passed to the [`RadialBasedImportanceSampling`](@ref) constructor, a FORM analysis will automatically be performed.
+
+```@example reliability
+rbis = RadialBasedImportanceSampling(1000)
+pf_rbis, std_rbis, samples = probability_of_failure(y, g, x, rbis)
+
+println("Probability of failure: $pf_rbis")
+println("Coefficient of variation: $(std_rbis/pf_rbis)")
+
+scatter(samples.x1, samples.x2; xlabel="x1", ylabel="x2") # hide
+savefig("rbis-samples.svg"); nothing # hide
+```
+
+A scatter plot cleary shows the exclusion of the β-sphere.
+![RBIS samples](rbis-samples.svg)

--- a/src/UncertaintyQuantification.jl
+++ b/src/UncertaintyQuantification.jl
@@ -130,6 +130,7 @@ export PolynomialChaosBasis
 export PolynomialChaosExpansion
 export PolyharmonicSpline
 export ProbabilityBox
+export RadialBasedImportanceSampling
 export RandomVariable
 export RandomSlicing
 export ResponseSurface
@@ -211,6 +212,7 @@ include("sensitivity/gradient.jl")
 include("simulations/doe.jl")
 include("simulations/linesampling.jl")
 include("simulations/montecarlo.jl")
+include("simulations/radialbasedimportancesampling.jl")
 include("simulations/subset.jl")
 
 include("reliability/form.jl")

--- a/src/UncertaintyQuantification.jl
+++ b/src/UncertaintyQuantification.jl
@@ -20,7 +20,6 @@ using QuasiMonteCarlo
 using Random
 using Reexport
 using Roots
-using SpecialFunctions
 using StatsBase
 
 @reexport using Distributions

--- a/src/UncertaintyQuantification.jl
+++ b/src/UncertaintyQuantification.jl
@@ -20,6 +20,7 @@ using QuasiMonteCarlo
 using Random
 using Reexport
 using Roots
+using SpecialFunctions
 using StatsBase
 
 @reexport using Distributions

--- a/src/reliability/form.jl
+++ b/src/reliability/form.jl
@@ -1,11 +1,11 @@
 """
     FORM(n::Integer=10,tol::Real=1e-3,fdm::FiniteDifferencesMethod=CentralFiniteDifferences(3))
 
-    used to perform the first order reliability method using the HLRF algorithm with `n` iterations and tolerance `tol`. Gradients are estimated through `fdm`.
+used to perform the first order reliability method using the HLRF algorithm with `n` iterations and tolerance `tol`. Gradients are estimated through `fdm`.
 
-    # References
+# References
 
-    [rackwitzStructuralReliability1978](@cite)
+[rackwitzStructuralReliability1978](@cite)
 """
 struct FORM <: AbstractSimulation
     n::Integer
@@ -24,11 +24,13 @@ end
 """
     probability_of_failure(models::Union{Vector{<:UQModel},UQModel},performance::Function),inputs::Union{Vector{<:UQInput},UQInput},sim::FORM)
 
-    Perform a reliability analysis using the first order reliability method (FORM), see [`FORM`](@ref).
-    Returns the estimated probability of failure `pf`, the reliability index `β` and the design point `dp`.
+Perform a reliability analysis using the first order reliability method (FORM), see [`FORM`](@ref).
+Returns the estimated probability of failure `pf`, the reliability index `β` and the design point `dp`.
 
-    ## Examples
-    pf, β, dp = probability_of_failure(model, performance, inputs, sim)
+## Examples
+```
+pf, β, dp = probability_of_failure(model, performance, inputs, sim)
+```
 """
 function probability_of_failure(
     models::Union{Vector{<:UQModel},UQModel},

--- a/src/reliability/form.jl
+++ b/src/reliability/form.jl
@@ -22,7 +22,7 @@ struct FORM <: AbstractSimulation
 end
 
 """
-    probability_of_failure_(models::Union{Vector{<:UQModel},UQModel},performance::Function),inputs::Union{Vector{<:UQInput},UQInput},sim::FORM)
+    probability_of_failure(models::Union{Vector{<:UQModel},UQModel},performance::Function),inputs::Union{Vector{<:UQInput},UQInput},sim::FORM)
 
     Perform a reliability analysis using the first order reliability method (FORM), see [`FORM`](@ref).
     Returns the estimated probability of failure `pf`, the reliability index `β` and the design point `dp`.

--- a/src/reliability/form.jl
+++ b/src/reliability/form.jl
@@ -1,3 +1,12 @@
+"""
+    FORM(n::Integer=10,tol::Real=1e-3,fdm::FiniteDifferencesMethod=CentralFiniteDifferences(3))
+
+    used to perform the first order reliability method using the HLRF algorithm with `n` iterations and tolerance `tol`. Gradients are estimated through `fdm`.
+
+    # References
+
+    [rackwitzStructuralReliability1978](@cite)
+"""
 struct FORM <: AbstractSimulation
     n::Integer
     tol::Real
@@ -12,6 +21,15 @@ struct FORM <: AbstractSimulation
     end
 end
 
+"""
+    probability_of_failure_(models::Union{Vector{<:UQModel},UQModel},performance::Function),inputs::Union{Vector{<:UQInput},UQInput},sim::FORM)
+
+    Perform a reliability analysis using the first order reliability method (FORM), see [`FORM`](@ref).
+    Returns the estimated probability of failure `pf`, the reliability index `β` and the design point `dp`.
+
+    ## Examples
+    pf, β, dp = probability_of_failure(model, performance, inputs, sim)
+"""
 function probability_of_failure(
     models::Union{Vector{<:UQModel},UQModel},
     performance::Function,

--- a/src/reliability/probabilityoffailure.jl
+++ b/src/reliability/probabilityoffailure.jl
@@ -245,15 +245,16 @@ function probability_of_failure(
     evaluate!(models, samples)
 
     # Probability of failure
-    random_inputs = filter(i -> isa(i, RandomUQInput), inputs)
 
-    n_rv = count_rvs(random_inputs)
+    n_rv = count_rvs(inputs)
 
-    pf = (1 - cdf(Chisq(n_rv), sim.β^2)) * sum(performance(samples) .< 0) / sim.n
+    N_f = sum(performance(samples) .< 0)
 
-    variance = (pf - pf^2) / sim.n
+    pf = (1 - cdf(Chisq(n_rv), sim.β^2)) * N_f / sim.n
 
-    return pf, sqrt(variance), samples
+    cov = sqrt((1 - N_f / sim.n) / N_f)
+
+    return pf, cov * pf, samples
 end
 
 # Allow to calculate the pf using only a performance function but no model

--- a/src/reliability/probabilityoffailure.jl
+++ b/src/reliability/probabilityoffailure.jl
@@ -1,12 +1,14 @@
 """
     probability_of_failure(models::Union{Vector{<:UQModel},UQModel},performance::Function),inputs::Union{Vector{<:UQInput},UQInput},sim::AbstractMonteCarlo)
 
-    Perform a reliability analysis with a standard Monte Carlo simulation.
-    Returns the estimated probability of failure `pf`, the standard deviation `σ` and the `DataFrame` containing the evaluated `samples`.
-    The simulation `sim` can be any instance of `AbstractMonteCarlo`.
+Perform a reliability analysis with a standard Monte Carlo simulation.
+Returns the estimated probability of failure `pf`, the standard deviation `σ` and the `DataFrame` containing the evaluated `samples`.
+The simulation `sim` can be any instance of `AbstractMonteCarlo`.
 
-    ## Examples
-    pf, σ, samples = probability_of_failure(model, performance, inputs, sim)
+## Examples
+```
+pf, σ, samples = probability_of_failure(model, performance, inputs, sim)
+```
 """
 function probability_of_failure(
     models::Union{Vector{<:UQModel},UQModel},

--- a/src/reliability/probabilityoffailure.jl
+++ b/src/reliability/probabilityoffailure.jl
@@ -235,7 +235,7 @@ function probability_of_failure(
         error("You must use DoubleLoop or RandomSlicing with imprecise inputs.")
     end
 
-    if isempty(sim.β)
+    if iszero(sim.β)
         _, β, _, _ = probability_of_failure(models, performance, inputs, FORM())
         sim.β = β
     end

--- a/src/reliability/probabilityoffailure.jl
+++ b/src/reliability/probabilityoffailure.jl
@@ -245,13 +245,16 @@ function probability_of_failure(
     evaluate!(models, samples)
 
     # Probability of failure
-    random_inputs = filter(i -> isa(i, RandomUQInput), inputs)
 
-    n_rv = count_rvs(random_inputs)
+    n_rv = count_rvs(inputs)
 
-    pf = (1 - cdf(Chisq(n_rv), sim.β^2)) * sum(performance(samples) .< 0) / sim.n
+    N_f = sum(performance(samples) .< 0)
 
-    variance = (pf - pf^2) / sim.n
+    pf = (1 - cdf(Chisq(n_rv), sim.β^2)) * N_f / sim.n
+
+    # volume of the exclusion sphere
+    V = π^(n_rv / 2) / gamma(n_rv / 2 + 1) * sim.β^n_rv
+    variance = (N_f * V / sim.n - pf^2) / sim.n
 
     return pf, sqrt(variance), samples
 end

--- a/src/reliability/probabilityoffailure.jl
+++ b/src/reliability/probabilityoffailure.jl
@@ -245,16 +245,13 @@ function probability_of_failure(
     evaluate!(models, samples)
 
     # Probability of failure
+    random_inputs = filter(i -> isa(i, RandomUQInput), inputs)
 
-    n_rv = count_rvs(inputs)
+    n_rv = count_rvs(random_inputs)
 
-    N_f = sum(performance(samples) .< 0)
+    pf = (1 - cdf(Chisq(n_rv), sim.β^2)) * sum(performance(samples) .< 0) / sim.n
 
-    pf = (1 - cdf(Chisq(n_rv), sim.β^2)) * N_f / sim.n
-
-    # volume of the exclusion sphere
-    V = π^(n_rv / 2) / gamma(n_rv / 2 + 1) * sim.β^n_rv
-    variance = (N_f * V / sim.n - pf^2) / sim.n
+    variance = (pf - pf^2) / sim.n
 
     return pf, sqrt(variance), samples
 end

--- a/src/reliability/probabilityoffailure.jl
+++ b/src/reliability/probabilityoffailure.jl
@@ -1,3 +1,13 @@
+"""
+    probability_of_failure_(models::Union{Vector{<:UQModel},UQModel},performance::Function),inputs::Union{Vector{<:UQInput},UQInput},sim::FORM)
+
+    Perform a reliability analysis with a standard Monte Carlo simulation.
+    Returns the estimated probability of failure `pf`, the standard deviation `σ` and the `DataFrame` containing the evaluated `samples`.
+    The simulation `sim` can be any instance of `AbstractMonteCarlo`.
+
+    ## Examples
+    pf, σ, samples = probability_of_failure(model, performance, inputs, sim)
+"""
 function probability_of_failure(
     models::Union{Vector{<:UQModel},UQModel},
     performance::Function,

--- a/src/reliability/probabilityoffailure.jl
+++ b/src/reliability/probabilityoffailure.jl
@@ -1,5 +1,5 @@
 """
-    probability_of_failure_(models::Union{Vector{<:UQModel},UQModel},performance::Function),inputs::Union{Vector{<:UQInput},UQInput},sim::FORM)
+    probability_of_failure(models::Union{Vector{<:UQModel},UQModel},performance::Function),inputs::Union{Vector{<:UQInput},UQInput},sim::AbstractMonteCarlo)
 
     Perform a reliability analysis with a standard Monte Carlo simulation.
     Returns the estimated probability of failure `pf`, the standard deviation `σ` and the `DataFrame` containing the evaluated `samples`.

--- a/src/simulations/radialbasedimportancesampling.jl
+++ b/src/simulations/radialbasedimportancesampling.jl
@@ -1,10 +1,18 @@
 """
-  RadialBasedImportanceSampling(n::Integer, β::Real)
+    RadialBasedImportanceSampling(n::Integer, β::Real)
 
-  Used to perform radial-based importance sampling with `n` samples and reliability index `β`.
-  If no `β`` or `β=0.0` is passed, a [`FORM`](@ref) analysis will automatically be performed to estimate the reliability index.
+Used to perform radial-based importance sampling with `n` samples and reliability index `β`.
+If no `β` or `β=0.0` is passed, a [`FORM`](@ref) analysis will automatically be performed to estimate the reliability index.
 
-  # References
+
+## Examples
+
+```jldoctest
+julia> rbis = RadialBasedImportanceSampling(1000)
+RadialBasedImportanceSampling(10000, 0.0)
+````
+
+## References
 
 [harbitzEfficientSamplingMethod1986](@cite)
 """

--- a/src/simulations/radialbasedimportancesampling.jl
+++ b/src/simulations/radialbasedimportancesampling.jl
@@ -55,5 +55,3 @@ function _samples_outside_beta_sphere(β::Real, k::Integer, n::Integer)
 
     return x
 end
-
-Χ

--- a/src/simulations/radialbasedimportancesampling.jl
+++ b/src/simulations/radialbasedimportancesampling.jl
@@ -1,0 +1,58 @@
+mutable struct RadialBasedImportanceSampling <: AbstractSimulation
+    n::Integer
+    β::Real
+end
+
+function RadialBasedImportanceSampling(n::Integer)
+    return RadialBasedImportanceSampling(n, 0.0)
+end
+
+function sample(inputs::Vector{<:UQInput}, sim::RadialBasedImportanceSampling)
+    random_inputs = filter(i -> isa(i, RandomUQInput), inputs)
+    deterministic_inputs = filter(i -> isa(i, DeterministicUQInput), inputs)
+
+    n_rv = count_rvs(random_inputs)
+    rv_names = names(random_inputs)
+
+    samples = DataFrame(
+        rv_names .=> eachcol(_samples_outside_beta_sphere(sim.β, n_rv, sim.n))
+    )
+
+    if !isempty(deterministic_inputs)
+        DataFrames.hcat!(samples, sample(deterministic_inputs, sim.n))
+    end
+
+    to_physical_space!(inputs, samples)
+
+    return samples
+end
+
+#=
+L. E. Blumenson, ‘A Derivation of n-Dimensional Spherical Coordinates’, The American Mathematical Monthly, vol. 67, no. 1, pp. 63–66, 1960, doi: 10.2307/2308932.
+=#
+function _samples_outside_beta_sphere(β::Real, k::Integer, n::Integer)
+    r = sqrt.(rand(truncated(Chisq(k), β^2, Inf), n))
+    if k == 1
+        return r
+    elseif k == 2
+        φ = rand(Uniform(0, 2π), n)
+
+        return [r .* cos.(φ) r .* sin.(φ)]
+    else
+        φ = rand(Uniform(0, π), (n, k - 2))
+
+        θ = rand(Uniform(0, 2π), n)
+
+        x = r .* cos.(φ[:, 1])
+
+        for j in 2:(k - 2)
+            x = hcat(x, r .* cos.(φ[:, j]) .* prod(sin.(φ[:, 1:(j - 1)]); dims=2))
+        end
+
+        x = hcat(x, r .* sin.(θ) .* prod(sin.(φ[:, 1:(k - 2)]); dims=2))
+
+        x = hcat(x, r .* cos.(θ) .* prod(sin.(φ[:, 1:(k - 2)]); dims=2))
+
+        return x
+    end
+end

--- a/src/simulations/radialbasedimportancesampling.jl
+++ b/src/simulations/radialbasedimportancesampling.jl
@@ -27,32 +27,21 @@ function sample(inputs::Vector{<:UQInput}, sim::RadialBasedImportanceSampling)
     return samples
 end
 
-#=
-L. E. Blumenson, ‘A Derivation of n-Dimensional Spherical Coordinates’, The American Mathematical Monthly, vol. 67, no. 1, pp. 63–66, 1960, doi: 10.2307/2308932.
-=#
 function _samples_outside_beta_sphere(β::Real, k::Integer, n::Integer)
+
+    # sample chi square distributed radius > β
     r = sqrt.(rand(truncated(Chisq(k), β^2, Inf), n))
-    if k == 1
-        return r
-    elseif k == 2
-        φ = rand(Uniform(0, 2π), n)
 
-        return [r .* cos.(φ) r .* sin.(φ)]
-    else
-        φ = rand(Uniform(0, π), (n, k - 2))
+    # standard normal samples
+    ϕ = rand(Normal(), (n, k))
+    # normalize each row to create samples on the surface of an n-sphere with radius 1.0
+    ϕ = ϕ ./ norm.(eachrow(ϕ))
 
-        θ = rand(Uniform(0, 2π), n)
+    # scale samples with the radius to > β
+    x = ϕ .* r
 
-        x = r .* cos.(φ[:, 1])
+    # error if samples are generated inside the sphere
+    @assert all(norm.(eachrow(x)) .> β)
 
-        for j in 2:(k - 2)
-            x = hcat(x, r .* cos.(φ[:, j]) .* prod(sin.(φ[:, 1:(j - 1)]); dims=2))
-        end
-
-        x = hcat(x, r .* sin.(θ) .* prod(sin.(φ[:, 1:(k - 2)]); dims=2))
-
-        x = hcat(x, r .* cos.(θ) .* prod(sin.(φ[:, 1:(k - 2)]); dims=2))
-
-        return x
-    end
+    return x
 end

--- a/src/simulations/radialbasedimportancesampling.jl
+++ b/src/simulations/radialbasedimportancesampling.jl
@@ -1,3 +1,13 @@
+"""
+  RadialBasedImportanceSampling(n::Integer, β::Real)
+
+  Used to perform radial-based importance sampling with `n` samples and reliability index `β`.
+  If no `β`` or `β=0.0` is passed, a [`FORM`](@ref) analysis will automatically be performed to estimate the reliability index.
+
+  # References
+
+[harbitzEfficientSamplingMethod1986](@cite)
+"""
 mutable struct RadialBasedImportanceSampling <: AbstractSimulation
     n::Integer
     β::Real
@@ -45,3 +55,5 @@ function _samples_outside_beta_sphere(β::Real, k::Integer, n::Integer)
 
     return x
 end
+
+Χ

--- a/test/reliability/probabilityoffailure.jl
+++ b/test/reliability/probabilityoffailure.jl
@@ -122,7 +122,7 @@
             [g1, g2],
             df -> min.(df.g1, df.g2),
             inputs,
-            RadialBasedImportanceSampling(10^6, 2.953),
+            RadialBasedImportanceSampling(10^4, 2.953),
         )
 
         @test isapprox(pf, 2.75e-3; rtol=0.1)
@@ -132,7 +132,7 @@
             [g1, g2],
             df -> max.(df.g1, df.g2),
             inputs,
-            RadialBasedImportanceSampling(10^6, 3.434),
+            RadialBasedImportanceSampling(10^4, 3.434),
         )
 
         @test isapprox(pf, 1.23e-4; rtol=0.1)

--- a/test/reliability/probabilityoffailure.jl
+++ b/test/reliability/probabilityoffailure.jl
@@ -125,7 +125,7 @@
             RadialBasedImportanceSampling(10^4, 2.953),
         )
 
-        @test isapprox(pf, 2.75e-3; rtol=0.1)
+        @test isapprox(pf, 2.57e-3; rtol=0.1)
 
         # reference solution 1.23e-4
         pf, cov, samples = probability_of_failure(

--- a/test/reliability/probabilityoffailure.jl
+++ b/test/reliability/probabilityoffailure.jl
@@ -132,7 +132,7 @@
             [g1, g2],
             df -> max.(df.g1, df.g2),
             inputs,
-            RadialBasedImportanceSampling(10^4, 3.434),
+            RadialBasedImportanceSampling(10^5, 3.434),
         )
 
         @test isapprox(pf, 1.23e-4; rtol=0.1)

--- a/test/reliability/probabilityoffailure.jl
+++ b/test/reliability/probabilityoffailure.jl
@@ -136,5 +136,16 @@
         )
 
         @test isapprox(pf, 1.23e-4; rtol=0.1)
+
+        # Englund and Rackwitz - A benchmark study on importance sampling techniques
+        # in structural reliability (1993)
+        # Example 1
+        u = RandomVariable.(Normal(), [:u1, :u2])
+
+        g = df -> 2^(1 / 2) .- (df.u1 .+ df.u2)
+
+        pf, _, _ = probability_of_failure(g, u, RadialBasedImportanceSampling(10000))
+
+        @test pf ≈ 0.159 rtol = 0.05
     end
 end

--- a/test/reliability/probabilityoffailure.jl
+++ b/test/reliability/probabilityoffailure.jl
@@ -28,8 +28,9 @@
     end
 
     @testset "Line sampling" begin
-
-        @test_throws ErrorException("LineSampling does not support lines longer than 8.12.") LineSampling(100, collect(0:0.1:10))
+        @test_throws ErrorException("LineSampling does not support lines longer than 8.12.") LineSampling(
+            100, collect(0:0.1:10)
+        )
 
         # Englund and Rackwitz - A benchmark study on importance sampling techniques
         # in structural reliability (1993)
@@ -109,5 +110,31 @@
 
         # 95% conf intervals estimated from 1000 runs
         @test 3.14e-11 < pf < 3.4e-10
+    end
+
+    @testset "Radial Based Importance Sampling" begin
+        inputs = RandomVariable.(Normal(), [:x1, :x2, :x3])
+        g1 = @. Model(df -> -df.x1 - df.x2 - df.x3 + 3 * sqrt(3), :g1)
+        g2 = @. Model(df -> -df.x3 + 3, :g2)
+
+        # reference solution 2.57e-3
+        pf, _, _ = probability_of_failure(
+            [g1, g2],
+            df -> min.(df.g1, df.g2),
+            inputs,
+            RadialBasedImportanceSampling(10^6, 2.953),
+        )
+
+        @test isapprox(pf, 2.75e-3; rtol=0.1)
+
+        # reference solution 1.23e-4
+        pf, cov, samples = probability_of_failure(
+            [g1, g2],
+            df -> max.(df.g1, df.g2),
+            inputs,
+            RadialBasedImportanceSampling(10^6, 3.434),
+        )
+
+        @test isapprox(pf, 1.23e-4; rtol=0.1)
     end
 end


### PR DESCRIPTION
This adds the base version of radial based importance sampling [1].

Obviously it's missing docs and tests but I'll add them before marking the PR as ready for review.

Closes #47.

### Reference

[1] A. Harbitz, ‘An efficient sampling method for probability of failure calculation’, Structural Safety, vol. 3, no. 2, pp. 109–115, Jan. 1986, doi: [10.1016/0167-4730(86)90012-3](https://doi.org/10.1016/0167-4730(86)90012-3).