### PR TITLE
Rework ProbabilityBox and Interval

### DIFF
--- a/.github/workflows/DemoFilesUpToDate.yml
+++ b/.github/workflows/DemoFilesUpToDate.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1.10'
+          version: "1.11"
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Check demo files

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v2
         with:
-          version: "1.10"
+          version: "1.11"
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/DocumentationPreview.yml
+++ b/.github/workflows/DocumentationPreview.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v2
         with:
-          version: "1.10"
+          version: "1.11"
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         julia-version:
-          - "1.10"
+          - "1.11"
         os:
           - "ubuntu-latest"
           - "windows-latest"
@@ -29,7 +29,7 @@ jobs:
       - uses: julia-actions/cache@v1
       - name: Update PATH on Linux
         if: runner.os == 'Linux'
-        run: echo "$PWD/test/test_utilities" >> $GITHUB_PATH 
+        run: echo "$PWD/test/test_utilities" >> $GITHUB_PATH
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4

--- a/demo/reliability/alvarez-2d-with-pboxes.jl
+++ b/demo/reliability/alvarez-2d-with-pboxes.jl
@@ -10,8 +10,8 @@ IS = ImportanceSampling(10^4)
 
 ## Alvarez model, from 10^6 interval MC he gets pf = [2.590 × 10−4, 0.503]
 
-X1 = RandomVariable(ProbabilityBox{Normal}([Interval(-1, 2, :μ), Parameter(1, :σ)]), :X1)
-X2 = RandomVariable(ProbabilityBox{Normal}([Interval(-2, 1, :μ), Parameter(2, :σ)]), :X2)
+X1 = RandomVariable(ProbabilityBox{Normal}(Dict(:μ => Interval(-1, 2), :σ => 1)), :X1)
+X2 = RandomVariable(ProbabilityBox{Normal}(Dict(:μ => Interval(-2, 1), :σ => 2)), :X2)
 
 inputs = [X1, X2]
 models = Model(df -> df.X1 .^ 2 .+ df.X2, :g)

--- a/demo/reliability/alvarez-2d-with-pboxes.jl
+++ b/demo/reliability/alvarez-2d-with-pboxes.jl
@@ -10,8 +10,8 @@ IS = ImportanceSampling(10^4)
 
 ## Alvarez model, from 10^6 interval MC he gets pf = [2.590 × 10−4, 0.503]
 
-X1 = ProbabilityBox{Normal}([Interval(-1, 2, :μ), Parameter(1, :σ)], :X1)
-X2 = ProbabilityBox{Normal}([Interval(-2, 1, :μ), Parameter(2, :σ)], :X2)
+X1 = RandomVariable(ProbabilityBox{Normal}([Interval(-1, 2, :μ), Parameter(1, :σ)]), :X1)
+X2 = RandomVariable(ProbabilityBox{Normal}([Interval(-2, 1, :μ), Parameter(2, :σ)]), :X2)
 
 inputs = [X1, X2]
 models = Model(df -> df.X1 .^ 2 .+ df.X2, :g)

--- a/demo/reliability/front_axle-with-pboxes.jl
+++ b/demo/reliability/front_axle-with-pboxes.jl
@@ -1,7 +1,11 @@
 using UncertaintyQuantification
 
-a = ProbabilityBox{Normal}([Interval(11, 13, :μ), Parameter(1.2, :σ)], :a, 0, Inf)
-t = ProbabilityBox{Normal}([Interval(13, 15, :μ), Parameter(1.4, :σ)], :t, 0, Inf)
+a = RandomVariable(
+    ProbabilityBox{Normal}(Dict(:μ => Interval(11, 13), :σ => 1.2), 0, Inf), :a
+)
+t = RandomVariable(
+    ProbabilityBox{Normal}(Dict(:μ => Interval(13, 15), :σ => 1.4), 0, Inf), :t
+)
 
 b = RandomVariable(truncated(Normal(65, 6.5), 0, Inf), :b)
 h = RandomVariable(truncated(Normal(85, 8.5), 0, Inf), :h)

--- a/demo/reliability/linesampling.jl
+++ b/demo/reliability/linesampling.jl
@@ -55,21 +55,26 @@ println("Model Calls = $(length(samples_MC.x1))")
 # Imprecise Analysis
 println("Performing Imprecise Reliability Analysis")
 
-mean = Interval(-0.2, 0.2, :μ)
-std = Interval(0.8, 1.2, :σ)
-x_pbox = ProbabilityBox{Normal}.(Ref([mean, std]), [:x1, :x2])
+μ = Interval(-0.2, 0.2)
+σ = Interval(0.8, 1.2)
+
+x = RandomVariable.(ProbabilityBox{Normal}(Dict(:μ => μ, :σ => σ)), [:x1, :x2])
 
 # Perform Line Sampling
-@time pf_ls_DL = probability_of_failure(
-    [y], g, x_pbox, DoubleLoop(LineSampling(numberlines, collect(0.5:0.5:8)))
+@time pf_ls_DL, x_lb_ls, x_ub_ls = probability_of_failure(
+    [y], g, x, DoubleLoop(LineSampling(numberlines, collect(0.5:0.5:8)))
 )
-@time pf_ls_RS, σ_pf_ls_RS, samples_ls_RS = probability_of_failure([y], g, x_pbox, RandomSlicing(LineSampling(numberlines, collect(0.5:0.5:8))))
+@time pf_ls_RS, σ_pf_ls_RS, samples_ls_RS = probability_of_failure(
+    [y], g, x, RandomSlicing(LineSampling(numberlines, collect(0.5:0.5:8)))
+)
 
 # Perform Advanced Line Sampling
-@time pf_als_DL = probability_of_failure(
-    [y], g, x_pbox, DoubleLoop(AdvancedLineSampling(numberlines, collect(0.5:0.5:8)))
+@time pf_als_DL, x_lb_als, x_ub_als = probability_of_failure(
+    [y], g, x, DoubleLoop(AdvancedLineSampling(numberlines, collect(0.5:0.5:8)))
 )
-@time pf_als_RS, σ_pf_als_RS, samples_als_RS = probability_of_failure([y], g, x_pbox, RandomSlicing(AdvancedLineSampling(numberlines, collect(0.5:0.5:8))))
+@time pf_als_RS, σ_pf_als_RS, samples_als_RS = probability_of_failure(
+    [y], g, x, RandomSlicing(AdvancedLineSampling(numberlines, collect(0.5:0.5:8)))
+)
 
 println("Double Loop:")
 println("Line Sampling pf = [$(pf_ls_DL.lb), $(pf_ls_DL.ub)]")

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -12,6 +12,19 @@
   langid  = {english}
 }
 
+@article{abramsonOrthoMADSDeterministicMADS2009,
+  title     = {{{OrthoMADS}}: {{A Deterministic MADS Instance}} with {{Orthogonal Directions}}},
+  author    = {Abramson, Mark A. and Audet, Charles and Dennis,, J. E. and Digabel, Sébastien Le},
+  year      = {2001},
+  journal   = {SIAM Journal on Optimization},
+  volume    = {20},
+  number    = {2},
+  pages     = {948--966},
+  publisher = {{Society for Industrial and Applied Mathematics}},
+  doi       = {10.1137/080716980}
+}
+
+
 @article{aughenbaughValueUsingImprecise2005,
   title   = {The {{Value}} of {{Using Imprecise Probabilities}} in {{Engineering Design}}},
   author  = {Aughenbaugh, Jason Matthew and Paredis, Christiaan J. J.},

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,3 +1,26 @@
+@article{abramsonOrthoMADSDeterministicMADS2009,
+  title     = {{{OrthoMADS}}: {{A Deterministic MADS Instance}} with {{Orthogonal Directions}}},
+  author    = {Abramson, Mark A. and Audet, Charles and Dennis,, J. E. and Digabel, Sébastien Le},
+  year      = {2001},
+  journal   = {SIAM Journal on Optimization},
+  volume    = {20},
+  number    = {2},
+  pages     = {948--966},
+  publisher = {{Society for Industrial and Applied Mathematics}},
+  doi       = {10.1137/080716980}
+}
+
+@article{alvarez2018estimation,
+  title     = {Estimation of the lower and upper bounds on the probability of failure using subset simulation and random set theory},
+  author    = {Alvarez, Diego A and Uribe, Felipe and Hurtado, Jorge E},
+  journal   = {Mechanical Systems and Signal Processing},
+  volume    = {100},
+  pages     = {782--801},
+  year      = {2018},
+  publisher = {Elsevier}
+}
+
+
 @article{auEstimationSmallFailure2001,
   title   = {Estimation of Small Failure Probabilities in High Dimensions by Subset Simulation},
   author  = {Au, Siu-Kui and Beck, James L.},
@@ -12,19 +35,6 @@
   langid  = {english}
 }
 
-@article{abramsonOrthoMADSDeterministicMADS2009,
-  title     = {{{OrthoMADS}}: {{A Deterministic MADS Instance}} with {{Orthogonal Directions}}},
-  author    = {Abramson, Mark A. and Audet, Charles and Dennis,, J. E. and Digabel, Sébastien Le},
-  year      = {2001},
-  journal   = {SIAM Journal on Optimization},
-  volume    = {20},
-  number    = {2},
-  pages     = {948--966},
-  publisher = {{Society for Industrial and Applied Mathematics}},
-  doi       = {10.1137/080716980}
-}
-
-
 @article{aughenbaughValueUsingImprecise2005,
   title   = {The {{Value}} of {{Using Imprecise Probabilities}} in {{Engineering Design}}},
   author  = {Aughenbaugh, Jason Matthew and Paredis, Christiaan J. J.},
@@ -36,6 +46,7 @@
   issn    = {1050-0472},
   doi     = {10.1115/1.2204976}
 }
+
 
 @article{auRareEventSimulation2016,
   title    = {Rare Event Simulation in Finite-Infinite Dimensional Space},
@@ -50,7 +61,6 @@
   langid   = {english},
   keywords = {Curse of dimension,Markov Chain Monte Carlo,Monte Carlo,Rare Event,Subset Simulation}
 }
-
 
 @article{biBhattacharyyaDistanceEnriching2019,
   title      = {The {{Bhattacharyya}} Distance: {{Enriching}} the {{P-box}} in Stochastic Sensitivity Analysis},
@@ -74,6 +84,9 @@
   publisher = {Elsevier}
 }
 
+
+
+
 @article{chingTransitionalMarkovChain2007,
   title     = {Transitional {{Markov Chain Monte Carlo Method}} for {{Bayesian Model Updating}}, {{Model Class Selection}}, and {{Model Averaging}}},
   author    = {Ching, Jianye and Chen, Yi-Chu},
@@ -85,9 +98,6 @@
   publisher = {American Society of Civil Engineers},
   doi       = {10.1061/(ASCE)0733-9399(2007)133:7(816)}
 }
-
-
-
 
 @book{clough1975structures,
   title     = {Dynamics of Structures},
@@ -136,6 +146,17 @@
   doi      = {10.18637/jss.v098.i16}
 }
 
+@article{dubois1990consonant,
+  title     = {Consonant approximations of belief functions},
+  author    = {Dubois, Didier and Prade, Henri},
+  journal   = {International Journal of Approximate Reasoning},
+  volume    = {4},
+  number    = {5-6},
+  pages     = {419--449},
+  year      = {1990},
+  publisher = {Elsevier}
+}
+
 @techreport{fersonConstructingProbabilityBoxes2015,
   title       = {Constructing {{Probability Boxes}} and {{Dempster-Shafer Structures}}},
   author      = {Ferson, Scott and Kreinovick, Vladik and Ginzburg, Lev and Sentz, Fari and Meyers, Davis},
@@ -170,6 +191,7 @@
   doi     = {10.1093/biomet/57.1.97}
 }
 
+
 @book{joeDependenceModelingCopulas2015,
   title     = {Dependence {{Modeling}} with {{Copulas}}},
   author    = {Joe, Harry},
@@ -187,7 +209,6 @@
   pages   = {309--325},
   year    = {1957}
 }
-
 
 @article{kiureghianAleatoryEpistemicDoes2009,
   title      = {Aleatory or Epistemic? {{Does}} It Matter?},
@@ -339,6 +360,24 @@
   pagetotal = {356}
 }
 
+
+@article{schmelzer2023random,
+  title     = {Random sets, copulas and related sets of probability measures},
+  author    = {Schmelzer, Bernhard},
+  journal   = {International Journal of Approximate Reasoning},
+  volume    = {160},
+  pages     = {108952},
+  year      = {2023},
+  publisher = {Elsevier}
+}
+
+@book{shafer1976mathematical,
+  title     = {A Mathematical Theory of Evidence},
+  author    = {Shafer, Glenn},
+  year      = {1976},
+  publisher = {Princeton university press}
+}
+
 @article{sheatherReliableDataBasedBandwidth1991,
   title   = {A {{Reliable Data-Based Bandwidth Selection Method}} for {{Kernel Density Estimation}}},
   author  = {Sheather, S. J. and Jones, M. C.},
@@ -349,7 +388,6 @@
   pages   = {683--690},
   doi     = {10.1111/j.2517-6161.1991.tb01857.x}
 }
-
 
 @article{shinozuka1991simulation,
   title     = {Simulation of stochastic processes by spectral representation},
@@ -373,6 +411,7 @@
   isbn      = {978-0-412-24620-3},
   pagetotal = {176}
 }
+
 
 @article{sklarFonctionsRepartitionDimensions1959,
   title    = {Fonctions de repartition a n dimensions et leurs marges},
@@ -404,9 +443,3 @@
   doi        = {10.1007/978-3-642-36197-5_165-1},
   langid     = {english}
 }
-<<<<<<< HEAD
-
-
-
-=======
->>>>>>> master

--- a/docs/src/api/inputs.md
+++ b/docs/src/api/inputs.md
@@ -10,11 +10,13 @@ Pages = ["inputs.md"]
 
 ```@docs
 Parameter
-RandomVariable
-EmpiricalDistribution
 Interval
-IntervalVariable
 ProbabilityBox
+RandomVariable
+IntervalVariable
+EmpiricalDistribution
+
+
 ```
 
 ## Functions

--- a/docs/src/api/inputs.md
+++ b/docs/src/api/inputs.md
@@ -13,6 +13,7 @@ Parameter
 RandomVariable
 EmpiricalDistribution
 Interval
+IntervalVariable
 ProbabilityBox
 ```
 

--- a/docs/src/api/reliability.md
+++ b/docs/src/api/reliability.md
@@ -10,6 +10,8 @@ Pages = ["reliability.md"]
 
 ```@docs
 FORM
+DoubleLoop
+RandomSlicing
 ```
 
 ## Methods

--- a/docs/src/manual/gettingstarted.md
+++ b/docs/src/manual/gettingstarted.md
@@ -47,6 +47,32 @@ to_standard_normal_space!(x, samples)
 to_physical_space!(x, samples)
 ```
 
+### Imprecise Probabilities
+
+To represent purely epistemic uncertainty we provide the [`IntervalVariable`](@ref) type.
+
+```@example interval
+  x = IntervalVariable(-1,2, :x)
+```
+
+Hybrid uncertainties can be expressed as probability boxes (p-box) using the [`ProbabilityBox`](@ref) type. Constructing a [`ProbabilityBox`](@ref) requires a `Dict` mapping all parameters of a `UnivariateDistribution` to either a `Real` or an [`Interval`](@ref). A [`ProbabilityBox`](@ref) is then wrapped in a [`RandomVariable`](@ref) to be used as an input in an analysis.
+
+```@example pbox
+  parameters = Dict(:μ => Interval(-1,1), :σ => 1)
+ pbox = ProbabilityBox{Normal}(parameters)
+ x = RandomVariable(pbox, :x)
+```
+
+!!! note "Interval and IntervalVariable"
+    The [`Interval`](@ref) type is internally used as a data type and to construct a [`ProbabilityBox`](@ref) while the [`IntervalVariable`] represents interval variables.
+
+Truncated p-boxes can be created by passing optional lower and upper bounds to the constructor.
+
+```@example pbox
+ pbox = ProbabilityBox{Normal}(parameters, 0, Inf)
+ x = RandomVariable(pbox, :x)
+```
+
 ## Dependencies
 
 *UncertaintyQuantification* supports modelling of dependencies through copulas. By using copulas, the modelling of the dependence structure is separated from the modelling of the univariate marginal distributions. The basis for copulas is given by Sklar's theorem [sklarFonctionsRepartitionDimensions1959](@cite). It states that any multivariate distribution ``H`` in dimensions ``d \geq 2`` can be separated into its marginal distributions ``F_i`` and a copula function ``C``.

--- a/docs/src/manual/gettingstarted.md
+++ b/docs/src/manual/gettingstarted.md
@@ -51,24 +51,24 @@ to_physical_space!(x, samples)
 
 To represent purely epistemic uncertainty we provide the [`IntervalVariable`](@ref) type.
 
-```@example interval
+```@example rv
   x = IntervalVariable(-1,2, :x)
 ```
 
 Hybrid uncertainties can be expressed as probability boxes (p-box) using the [`ProbabilityBox`](@ref) type. Constructing a [`ProbabilityBox`](@ref) requires a `Dict` mapping all parameters of a `UnivariateDistribution` to either a `Real` or an [`Interval`](@ref). A [`ProbabilityBox`](@ref) is then wrapped in a [`RandomVariable`](@ref) to be used as an input in an analysis.
 
-```@example pbox
+```@example rv
   parameters = Dict(:μ => Interval(-1,1), :σ => 1)
  pbox = ProbabilityBox{Normal}(parameters)
  x = RandomVariable(pbox, :x)
 ```
 
 !!! note "Interval and IntervalVariable"
-    The [`Interval`](@ref) type is internally used as a data type and to construct a [`ProbabilityBox`](@ref) while the [`IntervalVariable`] represents interval variables.
+    The [`Interval`](@ref) type is internally used as a data type and to construct a [`ProbabilityBox`](@ref) while the [`IntervalVariable`](@ref) represents interval variables.
 
 Truncated p-boxes can be created by passing optional lower and upper bounds to the constructor.
 
-```@example pbox
+```@example rv
  pbox = ProbabilityBox{Normal}(parameters, 0, Inf)
  x = RandomVariable(pbox, :x)
 ```

--- a/docs/src/manual/introduction.md
+++ b/docs/src/manual/introduction.md
@@ -58,6 +58,6 @@ Special algorithms must be used to propagate the epistemic uncertainty through m
 In *UncertaintyQuantification.jl* the four categories of uncertainties are described using the following objects:
 
 - Category I: [`Parameter`](@ref)
-- Category II: [`Interval`](@ref)
+- Category II: [`IntervalVariable`](@ref)
 - Category III: [`RandomVariable`](@ref)
 - Category IV: [`ProbabilityBox`](@ref).

--- a/src/UncertaintyQuantification.jl
+++ b/src/UncertaintyQuantification.jl
@@ -111,6 +111,7 @@ export HaltonSampling
 export HermiteBasis
 export ImportanceSampling
 export Interval
+export IntervalVariable
 export JointDistribution
 export KanaiTajimi
 export LatinHypercubeSampling

--- a/src/UncertaintyQuantification.jl
+++ b/src/UncertaintyQuantification.jl
@@ -30,7 +30,6 @@ import Statistics: mean, var
 
 abstract type UQInput end
 abstract type DeterministicUQInput <: UQInput end
-abstract type ImpreciseUQInput <: UQInput end
 abstract type RandomUQInput <: UQInput end
 
 """
@@ -83,7 +82,6 @@ export AbstractSimulation
 export Copula
 export DeterministicUQInput
 export RandomUQInput
-export ImpreciseUQInput
 export UQInput
 export UQModel
 

--- a/src/inputs/imprecise/interval.jl
+++ b/src/inputs/imprecise/interval.jl
@@ -65,7 +65,7 @@ struct IntervalVariable <: UQInput
 end
 
 function Base.show(io::IO, i::IntervalVariable)
-    print(io, "$(String(i.name)) ∈ [$(i.lb),$(i.ub)]")
+    print(io, "$(String(i.name)) ∈ [$(i.lb), $(i.ub)]")
     return nothing
 end
 

--- a/src/inputs/imprecise/interval.jl
+++ b/src/inputs/imprecise/interval.jl
@@ -42,7 +42,7 @@ end
 """
 	IntervalVariable(lb::Real, up::real, name::Symbol)
 
-Defines an IntervalVariable input , with lower bound `lb`, upper bound `ub` and `name.
+Defines an IntervalVariable input , with lower bound `lb`, upper bound `ub` and `name`.
 
 This is an input type. To construct p-boxes with interval parameters use [`Interval`](@ref)
 

--- a/src/inputs/imprecise/interval.jl
+++ b/src/inputs/imprecise/interval.jl
@@ -13,7 +13,8 @@ Represents a closed numeric interval with a lower bound `lb` and an upper bound 
 
 ```jldoctest
 julia> Interval(0.10, 0.14)
-Interval(0.1, 0.14)
+[0.1, 0.14]
+```
 """
 struct Interval
     lb::Real
@@ -60,7 +61,8 @@ For other uses, such as building probability boxes (p-boxes) from interval param
 
 ```jldoctest
 julia> IntervalVariable(0.10, 0.14, :x)
-IntervalVariable(0.1, 0.14, :x)
+x ∈ [0.1, 0.14]
+```
 """
 struct IntervalVariable <: UQInput
     lb::Real

--- a/src/inputs/imprecise/interval.jl
+++ b/src/inputs/imprecise/interval.jl
@@ -21,6 +21,10 @@ struct Interval <: ImpreciseUQInput
     end
 end
 
+function Interval(bounds::NamedTuple, name::Symbol)
+    return Interval(bounds.lb, bounds.ub, name)
+end
+
 function map_to_precise(x::Real, input::Interval)
     if !in(x, input)
         error("$x not in [$(input.lb), $(input.ub)] for Interval $(input.name).")

--- a/src/inputs/imprecise/interval.jl
+++ b/src/inputs/imprecise/interval.jl
@@ -1,15 +1,19 @@
 """
-	Interval(lb::Real, up::real)
+    Interval(lb::Real, ub::Real)
 
-Defines an Interval, with lower a bound, an upper bound.
+Represents a closed numeric interval with a lower bound `lb` and an upper bound `ub`.
 
-This is a data type used internally and to construct p-boxes. For interval inputs see [`IntervalVariable`](@ref).
+`Interval` is a data type primarily used for constructing probability boxes (p-boxes) and other uncertainty representations. It is **not** intended for direct use in simulations for that, see [`IntervalVariable`](@ref).
+
+# Fields
+- `lb::Real`: Lower bound of the interval.
+- `ub::Real`: Upper bound of the interval.
 
 # Examples
 
 ```jldoctest
 julia> Interval(0.10, 0.14)
-Interval(0.1, 0.14)```
+Interval(0.1, 0.14)
 """
 struct Interval
     lb::Real
@@ -40,17 +44,23 @@ function bounds(i::Interval)
 end
 
 """
-	IntervalVariable(lb::Real, up::real, name::Symbol)
+    IntervalVariable(lb::Real, ub::Real, name::Symbol)
 
-Defines an IntervalVariable input , with lower bound `lb`, upper bound `ub` and `name`.
+Defines an interval variable with a lower bound `lb`, upper bound `ub`, and an identifying `name`.
 
-This is an input type. To construct p-boxes with interval parameters use [`Interval`](@ref)
+`IntervalVariable` can be passed directly to analyses and simulations.
+For other uses, such as building probability boxes (p-boxes) from interval parameters, use [`Interval`](@ref) instead.
+
+# Fields
+- `lb::Real`: Lower bound of the interval.
+- `ub::Real`: Upper bound of the interval.
+- `name::Symbol`: Name or identifier for the variable.
 
 # Examples
 
 ```jldoctest
-julia> Interval(0.10, 0.14, :x)
-Interval(0.1, 0.14, :x)```
+julia> IntervalVariable(0.10, 0.14, :x)
+IntervalVariable(0.1, 0.14, :x)
 """
 struct IntervalVariable <: UQInput
     lb::Real

--- a/src/inputs/imprecise/interval.jl
+++ b/src/inputs/imprecise/interval.jl
@@ -1,19 +1,62 @@
 """
-	Interval(lb::Real, up::real, name::Symbol)
+	Interval(lb::Real, up::real)
 
-Defines an Interval, with lower a bound, an upper bound and a name.
+Defines an Interval, with lower a bound, an upper bound.
+
+This is a data type used internally and to construct p-boxes. For interval inputs see [`IntervalVariable`](@ref).
 
 # Examples
 
 ```jldoctest
-julia> Interval(0.10, 0.14, :b)
-Interval(0.1, 0.14, :b)```
+julia> Interval(0.10, 0.14)
+Interval(0.1, 0.14)```
 """
-struct Interval <: ImpreciseUQInput
+struct Interval
+    lb::Real
+    ub::Real
+    function Interval(lb::Real, ub::Real)
+        lb > ub && error(
+            "Lower bound parameter must be smaller than upper bound parameter for Intervals.",
+        )
+        return new(lb, ub)
+    end
+end
+
+function Base.show(io::IO, i::Interval)
+    print(io, "[$(i.lb), $(i.ub)]")
+    return nothing
+end
+
+Base.in(u, i::Interval) = i.lb <= u <= i.ub
+
+Base.broadcastable(i::Interval) = Ref(i)
+
+function isdegenerate(i::Interval)
+    return i.lb == i.ub
+end
+
+function bounds(i::Interval)
+    return i.lb, i.ub
+end
+
+"""
+	IntervalVariable(lb::Real, up::real, name::Symbol)
+
+Defines an IntervalVariable input , with lower bound `lb`, upper bound `ub` and `name.
+
+This is an input type. To construct p-boxes with interval parameters use [`Interval`](@ref)
+
+# Examples
+
+```jldoctest
+julia> Interval(0.10, 0.14, :x)
+Interval(0.1, 0.14, :x)```
+"""
+struct IntervalVariable <: UQInput
     lb::Real
     ub::Real
     name::Symbol
-    function Interval(lb::Real, ub::Real, name::Symbol)
+    function IntervalVariable(lb::Real, ub::Real, name::Symbol)
         lb > ub && error(
             "Lower bound parameter must be smaller than upper bound parameter for Interval $name.",
         )
@@ -21,32 +64,33 @@ struct Interval <: ImpreciseUQInput
     end
 end
 
-function Interval(bounds::NamedTuple, name::Symbol)
-    return Interval(bounds.lb, bounds.ub, name)
+function Base.show(io::IO, i::IntervalVariable)
+    print(io, "$(String(i.name)) ∈ [$(i.lb),$(i.ub)]")
+    return nothing
 end
 
-function map_to_precise(x::Real, input::Interval)
+function Interval(i::IntervalVariable)
+    return Interval(i.lb, i.ub)
+end
+
+function sample(i::IntervalVariable, n::Integer=1)
+    return DataFrame(i.name => fill(Interval(i), n))
+end
+
+function map_to_precise(x::Real, input::IntervalVariable)
     if !in(x, input)
         error("$x not in [$(input.lb), $(input.ub)] for Interval $(input.name).")
     end
     return Parameter(x, input.name)
 end
 
-function sample(i::Interval, n::Integer=1)
-    return DataFrame(i.name => fill(i, n))
-end
+to_standard_normal_space!(_::IntervalVariable, _::DataFrame) = nothing
+to_physical_space!(_::IntervalVariable, _::DataFrame) = nothing
 
-to_standard_normal_space!(i::Interval, x::DataFrame) = nothing
-to_physical_space!(i::Interval, x::DataFrame) = nothing
-
-mean(i::Interval) = i
-
-function bounds(i::Interval)
+function bounds(i::IntervalVariable)
     return i.lb, i.ub
 end
 
-Base.in(u, i::Interval) = i.lb <= u <= i.ub
+Base.in(u, i::IntervalVariable) = i.lb <= u <= i.ub
 
-function isdegenerate(i::Interval)
-    return i.lb == i.ub
-end
+mean(i::IntervalVariable) = Interval(i)

--- a/src/inputs/imprecise/interval.jl
+++ b/src/inputs/imprecise/interval.jl
@@ -106,3 +106,4 @@ end
 Base.in(u, i::IntervalVariable) = i.lb <= u <= i.ub
 
 mean(i::IntervalVariable) = Interval(i)
+var(i::IntervalVariable) = Interval(0.0, (i.ub - i.lb)^2 / 4)

--- a/src/inputs/imprecise/p-box.jl
+++ b/src/inputs/imprecise/p-box.jl
@@ -1,18 +1,31 @@
 """
-	ProbabilityBox{T}(p::Dict{Symbol,Union{Real,Interval}})
+    ProbabilityBox{T}(parameters::Dict{Symbol, Union{Real, Interval}}, lb::Real, ub::Real)
+    ProbabilityBox{T}(parameters::Dict{Symbol, Union{Real, Interval}})
+    ProbabilityBox{T}(parameter::Interval)
 
-Defines a `ProbabilityBox` from a `Dict` mapping each of the parameters of the `UnivariateDistribution` `T` to a `Real` or [`Interval`](@ref).
+Represents a (optionally truncated) probability box (p-box) for a univariate distribution `T`, where parameters may be specified as precise values (`Real`) or intervals (`Interval`). The support of the distribution is bounded by `lb` (lower bound) and `ub` (upper bound).
+
+# Fields
+- `parameters::Dict{Symbol, Union{Real, Interval}}`: Dictionary mapping parameter names (as symbols) to their values or intervals.
+- `lb::Real`: Lower bound of the distribution's support.
+- `ub::Real`: Upper bound of the distribution's support.
+
+# Constructors
+- `ProbabilityBox{T}(parameters::Dict{Symbol, Union{Real, Interval}}, lb::Real, ub::Real)`: Specify all parameters and support bounds explicitly.
+- `ProbabilityBox{T}(parameters::Dict{Symbol, Union{Real, Interval}})`: Support bounds are inferred from the distribution type `T`.
+- `ProbabilityBox{T}(parameter::Interval)`: For univariate distributions with a single parameter, construct from a single interval.
 
 # Examples
 
 ```jldoctest
-julia>  ProbabilityBox{Uniform}(Dict(:a => Interval(1.75, 1.83), :b => Interval(1.77, 1.85)))
-ProbabilityBox{Uniform}(Dict{Symbol, Union{Real, Interval}}(:a => [1.75, 1.83], :b => [1.77, 1.85]), 1.75, 1.85)
-```
+julia> ProbabilityBox{Normal}(Dict(:μ => Interval(0, 1), :σ => Interval(0.1, 1)), 0.0, Inf)
+ProbabilityBox{Normal}(Dict{Symbol, Union{Real, Interval}}(:μ => [0, 1], :σ => [0.1, 1]), 0.0, Inf)
 
-```jldoctest
-julia>  ProbabilityBox{Normal}(Dict(:μ => Interval(0, 1), :σ =>  Interval(0.1, 1)))
+julia> ProbabilityBox{Normal}(Dict(:μ => Interval(0, 1), :σ => Interval(0.1, 1)))
 ProbabilityBox{Normal}(Dict{Symbol, Union{Real, Interval}}(:μ => [0, 1], :σ => [0.1, 1]), -Inf, Inf)
+
+julia> ProbabilityBox{Exponential}(Interval(0.1, 0.5))
+ProbabilityBox{Exponential}(Dict{Symbol, Union{Real, Interval}}(:θ => [0.1, 0.5]), 0.0, Inf)
 ```
 """
 struct ProbabilityBox{T<:UnivariateDistribution}
@@ -38,20 +51,6 @@ struct ProbabilityBox{T<:UnivariateDistribution}
     end
 end
 
-"""
-	ProbabilityBox{T}(p::Dict{Symbol,Union{Real,Interval}}, lb::Real, ub::Real)
-
-Defines a truncated `ProbabilityBox` from a `Dict` mapping each of the parameters of the `UnivariateDistribution` `T` to a `Real` or [`Interval`](@ref).
-
-The parameters `lb` and `ub` define the lower and upper bound of the support.
-
-# Examples
-
-```jldoctest
-julia>  ProbabilityBox{Normal}(Dict(:μ => Interval(0, 1), :σ =>  Interval(0.1, 1)), 0, Inf)
-ProbabilityBox{Normal}(Dict{Symbol, Union{Real, Interval}}(:μ => [0, 1], :σ => [0.1, 1]), 0, Inf)
-```
-"""
 function ProbabilityBox{T}(p::Dict{Symbol,<:Any}) where {T<:UnivariateDistribution}
     domain = support(T())
     return ProbabilityBox{T}(p, domain.lb, domain.ub)

--- a/src/inputs/imprecise/p-box.jl
+++ b/src/inputs/imprecise/p-box.jl
@@ -5,6 +5,8 @@
 
 Represents a (optionally truncated) probability box (p-box) for a univariate distribution `T`, where parameters may be specified as precise values (`Real`) or intervals ([`Interval`](@ref)). The support of the distribution is bounded by `lb` (lower bound) and `ub` (upper bound).
 
+To use the `ProbabilityBox` in an analysis it has to be wrapped in a [`RandomVariable`](@ref).
+
 # Fields
 - `parameters::Dict{Symbol, Union{Real, Interval}}`: Dictionary mapping parameter names (as symbols) to their values or intervals.
 - `lb::Real`: Lower bound of the distribution's support.

--- a/src/inputs/imprecise/p-box.jl
+++ b/src/inputs/imprecise/p-box.jl
@@ -3,7 +3,7 @@
     ProbabilityBox{T}(parameters::Dict{Symbol, Union{Real, Interval}})
     ProbabilityBox{T}(parameter::Interval)
 
-Represents a (optionally truncated) probability box (p-box) for a univariate distribution `T`, where parameters may be specified as precise values (`Real`) or intervals (`Interval`). The support of the distribution is bounded by `lb` (lower bound) and `ub` (upper bound).
+Represents a (optionally truncated) probability box (p-box) for a univariate distribution `T`, where parameters may be specified as precise values (`Real`) or intervals ([`Interval`](@ref)). The support of the distribution is bounded by `lb` (lower bound) and `ub` (upper bound).
 
 # Fields
 - `parameters::Dict{Symbol, Union{Real, Interval}}`: Dictionary mapping parameter names (as symbols) to their values or intervals.

--- a/src/inputs/imprecise/p-box.jl
+++ b/src/inputs/imprecise/p-box.jl
@@ -1,7 +1,5 @@
 """
     ProbabilityBox{T}(parameters::Dict{Symbol, Union{Real, Interval}}, lb::Real, ub::Real)
-    ProbabilityBox{T}(parameters::Dict{Symbol, Union{Real, Interval}})
-    ProbabilityBox{T}(parameter::Interval)
 
 Represents a (optionally truncated) probability box (p-box) for a univariate distribution `T`, where parameters may be specified as precise values (`Real`) or intervals ([`Interval`](@ref)). The support of the distribution is bounded by `lb` (lower bound) and `ub` (upper bound).
 

--- a/src/inputs/imprecise/p-box.jl
+++ b/src/inputs/imprecise/p-box.jl
@@ -64,7 +64,7 @@ function ProbabilityBox{T}(p::Dict{Symbol,Interval}) where {T<:UnivariateDistrib
     return ProbabilityBox{T}(convert(Dict{Symbol,Any}, p))
 end
 
-function map_to_distribution(
+function map_to_precise(
     x::AbstractVector{<:Real}, pbox::ProbabilityBox{T}
 ) where {T<:UnivariateDistribution}
     parameters = collect(getindex.(Ref(pbox.parameters), fieldnames(T)))
@@ -94,7 +94,7 @@ end
 
 function quantile(pbox::ProbabilityBox{T}, u::Real) where {T<:UnivariateDistribution}
     quantiles = map(
-        par -> quantile(map_to_distribution([par...], pbox), u),
+        par -> quantile(map_to_precise([par...], pbox), u),
         Iterators.product([[a, b] for (a, b) in zip(bounds(pbox)...)]...),
     )
 
@@ -117,12 +117,12 @@ function cdf(pbox::ProbabilityBox{T}, x::Real) where {T<:UnivariateDistribution}
     lb, ub = bounds(pbox)
 
     cdfs_lo = map(
-        par -> cdf(map_to_distribution([par...], pbox), x),
+        par -> cdf(map_to_precise([par...], pbox), x),
         Iterators.product([[a, b] for (a, b) in zip(lb, ub)]...),
     )
 
     cdfs_hi = map(
-        par -> cdf(map_to_distribution([par...], pbox), x),
+        par -> cdf(map_to_precise([par...], pbox), x),
         Iterators.product([[a, b] for (a, b) in zip(lb, ub)]...),
     )
 
@@ -136,12 +136,12 @@ function reverse_quantile(
     lb, ub = bounds(pbox)
 
     cdfs_lo = map(
-        par -> cdf(map_to_distribution([par...], pbox), x.lb),
+        par -> cdf(map_to_precise([par...], pbox), x.lb),
         Iterators.product([[a, b] for (a, b) in zip(lb, ub)]...),
     )
 
     cdfs_hi = map(
-        par -> cdf(map_to_distribution([par...], pbox), x.ub),
+        par -> cdf(map_to_precise([par...], pbox), x.ub),
         Iterators.product([[a, b] for (a, b) in zip(lb, ub)]...),
     )
 

--- a/src/inputs/imprecise/p-box.jl
+++ b/src/inputs/imprecise/p-box.jl
@@ -45,7 +45,7 @@ struct ProbabilityBox{T<:UnivariateDistribution}
         # If someone only passes Parameters, return a RandomVariable instead.
         if all(isa.(values(p), Real))
             @warn "ProbabilityBox() returns a UnivariateDistribution if no intervals are passed"
-            return T(getindex.(Ref(p), fieldnames(t))...)
+            return T(getindex.(Ref(p), fieldnames(T))...)
         end
         return new(convert(Dict{Symbol,Union{Real,Interval}}, p), lb, ub)
     end

--- a/src/inputs/imprecise/p-box.jl
+++ b/src/inputs/imprecise/p-box.jl
@@ -1,18 +1,18 @@
 """
-	ProbabilityBox{T}(p::AbstractVector{<:UQInput})
+	ProbabilityBox{T}(p::Dict{Symbol,Union{Real,Interval}})
 
-Defines an ProbabilityBox from a `Vector` of `UQInput` and `UnivariateDistribution` `T`. The number and order of parameters must match the parameters of the associated distribution from Distributions.jl.
+Defines an ProbabilityBox from a `Dict` mapping each of the parameters of the `UnivariateDistribution` `T` to a `Real` or `Interval`.
 
 # Examples
 
 ```jldoctest
-julia>  ProbabilityBox{Uniform}([Interval(1.75, 1.83, :a), Interval(1.77, 1.85, :b)], :l)
-ProbabilityBox{Uniform}(Interval[Interval(1.75, 1.83, :a), Interval(1.77, 1.85, :b)], :l, 1.75, 1.85)
+julia>  ProbabilityBox{Uniform}(Dict(:a => Interval(1.75, 1.83), :b => Interval(1.77, 1.85)))
+ProbabilityBox{Uniform}(Dict{Symbol, Union{Real, Interval}}(:a => [1.75, 1.83], :b => [1.77, 1.85]), 1.75, 1.85)
 ```
 
 ```jldoctest
-julia>  ProbabilityBox{Normal}([Interval(0, 1, :μ), Interval(0.1, 1, :σ)], :x)
-ProbabilityBox{Normal}(Interval[Interval(0, 1, :μ), Interval(0.1, 1, :σ)], :x, -Inf, Inf)
+julia>  ProbabilityBox{Normal}(Dict(:μ => Interval(0, 1), :σ =>  Interval(0.1, 1)))
+ProbabilityBox{Normal}(Dict{Symbol, Union{Real, Interval}}(:μ => [0, 1], :σ => [0.1, 1]), -Inf, Inf)
 ```
 """
 struct ProbabilityBox{T<:UnivariateDistribution}

--- a/src/inputs/jointdistribution.jl
+++ b/src/inputs/jointdistribution.jl
@@ -1,8 +1,8 @@
 struct JointDistribution <: RandomUQInput
-    marginals::Vector{RandomVariable}
+    marginals::Vector{<:RandomVariable}
     copula::Copula
 
-    function JointDistribution(marginals::Vector{RandomVariable}, copula::Copula)
+    function JointDistribution(marginals::Vector{<:RandomVariable}, copula::Copula)
         length(marginals) == dimensions(copula) ||
             error("Dimension mismatch between copula and marginals")
 

--- a/src/inputs/jointdistribution.jl
+++ b/src/inputs/jointdistribution.jl
@@ -52,3 +52,9 @@ names(jd::JointDistribution) = vec(map(x -> x.name, jd.marginals))
 mean(jd::JointDistribution) = mean.(jd.marginals)
 
 dimensions(jd::JointDistribution) = dimensions(jd.copula)
+
+function bounds(jd::JointDistribution)
+    b = map(bounds, filter(isimprecise, jd.marginals))
+
+    return vcat(getindex.(b, 1)...), vcat(getindex.(b, 2)...)
+end

--- a/src/inputs/jointdistribution.jl
+++ b/src/inputs/jointdistribution.jl
@@ -32,7 +32,11 @@ end
 
 function to_standard_normal_space!(jd::JointDistribution, x::DataFrame)
     for rv in jd.marginals
-        x[!, rv.name] = cdf.(rv.dist, x[:, rv.name])
+        if isa(rv.dist, ProbabilityBox)
+            x[!, rv.name] = reverse_quantile.(rv.dist, x[:, rv.name])
+        else
+            x[!, rv.name] = cdf.(rv.dist, x[:, rv.name])
+        end
     end
     uncorrelated_stdnorm = to_standard_normal_space(
         jd.copula, Matrix{Float64}(x[:, names(jd)])

--- a/src/inputs/randomvariables/parametric/distribution.jl
+++ b/src/inputs/randomvariables/parametric/distribution.jl
@@ -1,19 +1,33 @@
 function to_standard_normal_space!(
     rv::RandomVariable{<:UnivariateDistribution}, x::DataFrame
 )
-    # do nothing for standard normal rv
-    if isa(rv.dist, Normal) && params(rv.dist) == (0.0, 1.0)
-        return nothing
-    end
     x[!, rv.name] = quantile.(Normal(), cdf.(rv.dist, x[:, rv.name]))
     return nothing
 end
 
 function to_physical_space!(rv::RandomVariable{<:UnivariateDistribution}, x::DataFrame)
-    # do nothing for standard normal rv
-    if isa(rv.dist, Normal) && params(rv.dist) == (0.0, 1.0)
-        return nothing
-    end
     x[!, rv.name] = quantile.(rv.dist, cdf.(Normal(), x[:, rv.name]))
     return nothing
+end
+
+function to_standard_normal_space!(rv::RandomVariable{<:Normal}, x::DataFrame)
+    μ, σ = params(rv.dist)
+    # do nothing for standard normal rv
+    if μ == 0.0 && σ == 1.0
+        return nothing
+    else
+        x[!, rv.name] = (x[:, rv.name] .- μ) ./ σ
+        return nothing
+    end
+end
+
+function to_physical_space!(rv::RandomVariable{<:Normal}, x::DataFrame)
+    μ, σ = params(rv.dist)
+    # do nothing for standard normal rv
+    if μ == 0.0 && σ == 1.0
+        return nothing
+    else
+        x[!, rv.name] = x[:, rv.name] .* σ .+ μ
+        return nothing
+    end
 end

--- a/src/inputs/randomvariables/parametric/distribution.jl
+++ b/src/inputs/randomvariables/parametric/distribution.jl
@@ -1,0 +1,19 @@
+function to_standard_normal_space!(
+    rv::RandomVariable{<:UnivariateDistribution}, x::DataFrame
+)
+    # do nothing for standard normal rv
+    if isa(rv.dist, Normal) && params(rv.dist) == (0.0, 1.0)
+        return nothing
+    end
+    x[!, rv.name] = quantile.(Normal(), cdf.(rv.dist, x[:, rv.name]))
+    return nothing
+end
+
+function to_physical_space!(rv::RandomVariable{<:UnivariateDistribution}, x::DataFrame)
+    # do nothing for standard normal rv
+    if isa(rv.dist, Normal) && params(rv.dist) == (0.0, 1.0)
+        return nothing
+    end
+    x[!, rv.name] = quantile.(rv.dist, cdf.(Normal(), x[:, rv.name]))
+    return nothing
+end

--- a/src/inputs/randomvariables/parametric/pbox.jl
+++ b/src/inputs/randomvariables/parametric/pbox.jl
@@ -1,0 +1,26 @@
+function sample(rv::RandomVariable{<:ProbabilityBox}, n::Integer=1)
+    return DataFrame(rv.name => Interval.(rand(rv.dist, n), rv.name))
+end
+
+function to_standard_normal_space!(rv::RandomVariable{<:ProbabilityBox}, x::DataFrame)
+    x[!, rv.name] =
+        quantile.(
+            Normal(),
+            reverse_quantile.(
+                Ref(rv.dist), map(i -> (lb=i.lb, ub=i.ub), collect(x[:, rv.name]))
+            ),
+        )
+    return nothing
+end
+
+function to_physical_space!(rv::RandomVariable{<:ProbabilityBox}, x::DataFrame)
+    x[!, rv.name] =
+        Interval.(quantile.(rv.dist, cdf.(Normal(), collect(x[:, rv.name]))), rv.name)
+    return nothing
+end
+
+bounds(rv::RandomVariable{<:ProbabilityBox}) = bounds(rv.dist)
+
+function map_to_precise(x::AbstractVector{<:Real}, rv::RandomVariable{<:ProbabilityBox})
+    return RandomVariable(map_to_distribution(x, rv.dist), rv.name)
+end

--- a/src/inputs/randomvariables/parametric/pbox.jl
+++ b/src/inputs/randomvariables/parametric/pbox.jl
@@ -1,21 +1,11 @@
-function sample(rv::RandomVariable{<:ProbabilityBox}, n::Integer=1)
-    return DataFrame(rv.name => Interval.(rand(rv.dist, n), rv.name))
-end
-
 function to_standard_normal_space!(rv::RandomVariable{<:ProbabilityBox}, x::DataFrame)
     x[!, rv.name] =
-        quantile.(
-            Normal(),
-            reverse_quantile.(
-                Ref(rv.dist), map(i -> (lb=i.lb, ub=i.ub), collect(x[:, rv.name]))
-            ),
-        )
+        quantile.(Normal(), reverse_quantile.(Ref(rv.dist), collect(x[:, rv.name])))
     return nothing
 end
 
 function to_physical_space!(rv::RandomVariable{<:ProbabilityBox}, x::DataFrame)
-    x[!, rv.name] =
-        Interval.(quantile.(rv.dist, cdf.(Normal(), collect(x[:, rv.name]))), rv.name)
+    x[!, rv.name] = quantile.(rv.dist, cdf.(Normal(), collect(x[:, rv.name])))
     return nothing
 end
 

--- a/src/inputs/randomvariables/parametric/pbox.jl
+++ b/src/inputs/randomvariables/parametric/pbox.jl
@@ -12,5 +12,5 @@ end
 bounds(rv::RandomVariable{<:ProbabilityBox}) = bounds(rv.dist)
 
 function map_to_precise(x::AbstractVector{<:Real}, rv::RandomVariable{<:ProbabilityBox})
-    return RandomVariable(map_to_distribution(x, rv.dist), rv.name)
+    return RandomVariable(map_to_precise(x, rv.dist), rv.name)
 end

--- a/src/inputs/randomvariables/randomvariable.jl
+++ b/src/inputs/randomvariables/randomvariable.jl
@@ -31,24 +31,6 @@ function sample(rv::RandomVariable, n::Integer=1)
     return DataFrame(rv.name => rand(rv.dist, n))
 end
 
-function to_standard_normal_space!(rv::RandomVariable, x::DataFrame)
-    # do nothing for standard normal rv
-    if isa(rv.dist, Normal) && params(rv.dist) == (0.0, 1.0)
-        return nothing
-    end
-    x[!, rv.name] = quantile.(Normal(), cdf.(rv.dist, x[:, rv.name]))
-    return nothing
-end
-
-function to_physical_space!(rv::RandomVariable, x::DataFrame)
-    # do nothing for standard normal rv
-    if isa(rv.dist, Normal) && params(rv.dist) == (0.0, 1.0)
-        return nothing
-    end
-    x[!, rv.name] = quantile.(rv.dist, cdf.(Normal(), x[:, rv.name]))
-    return nothing
-end
-
 dimensions(rv::RandomVariable) = 1
 
 logpdf(rv::RandomVariable, x::Real) = logpdf(rv.dist, x)
@@ -60,3 +42,6 @@ maximum(rv::RandomVariable) = maximum(rv.dist)
 insupport(rv::RandomVariable, x::Real) = insupport(rv.dist, x)
 mean(rv::RandomVariable) = mean(rv.dist)
 var(rv::RandomVariable) = var(rv.dist)
+
+include("parametric/distribution.jl")
+include("parametric/pbox.jl")

--- a/src/inputs/randomvariables/randomvariable.jl
+++ b/src/inputs/randomvariables/randomvariable.jl
@@ -13,8 +13,8 @@ julia> RandomVariable(Exponential(1), :x)
 RandomVariable(Exponential{Float64}(θ=1.0), :x)
 ```
 """
-struct RandomVariable <: RandomUQInput
-    dist::UnivariateDistribution
+struct RandomVariable{T<:Union{UnivariateDistribution,ProbabilityBox}} <: RandomUQInput
+    dist::T
     name::Symbol
 end
 

--- a/src/inputs/randomvariables/randomvariable.jl
+++ b/src/inputs/randomvariables/randomvariable.jl
@@ -7,10 +7,10 @@ Defines a random variable, with a univariate distribution from Distributions.jl 
 
 ```jldoctest
 julia> RandomVariable(Normal(), :x)
-RandomVariable(Normal{Float64}(μ=0.0, σ=1.0), :x)
+RandomVariable{Normal{Float64}}(Normal{Float64}(μ=0.0, σ=1.0), :x)
 
 julia> RandomVariable(Exponential(1), :x)
-RandomVariable(Exponential{Float64}(θ=1.0), :x)
+RandomVariable{Exponential{Float64}}(Exponential{Float64}(θ=1.0), :x)
 ```
 """
 struct RandomVariable{T<:Union{UnivariateDistribution,ProbabilityBox}} <: RandomUQInput

--- a/src/models/imprecise/propagation.jl
+++ b/src/models/imprecise/propagation.jl
@@ -82,7 +82,7 @@ function propagate_intervals!(
                 min_mesh_size=1e-13,
             )
 
-            return Interval(result_lb.f, -result_ub.f, output)
+            return Interval(result_lb.f, -result_ub.f)
         end
     end
 

--- a/src/models/imprecise/propagation.jl
+++ b/src/models/imprecise/propagation.jl
@@ -12,14 +12,15 @@ function propagate_intervals!(
     output = isa(m, AbstractVector) ? m[end].name : m.name
 
     y = map(eachrow(df)) do row
-
         degenerates = isdegenerate.(collect(row[interval_names]))
         pure = .!degenerates
 
         lb, ub = if any(degenerates)
-            getproperty.(collect(row[interval_names[pure]]), :lb), getproperty.(collect(row[interval_names[pure]]), :ub)
+            getproperty.(collect(row[interval_names[pure]]), :lb),
+            getproperty.(collect(row[interval_names[pure]]), :ub)
         else
-            getproperty.(collect(row[interval_names]), :lb), getproperty.(collect(row[interval_names]), :ub)
+            getproperty.(collect(row[interval_names]), :lb),
+            getproperty.(collect(row[interval_names]), :ub)
         end
 
         x0 = middle.(lb, ub)
@@ -32,7 +33,8 @@ function propagate_intervals!(
 
         # set degenerate intervals to their precise value
         if any(degenerates)
-            precise_df[1, interval_names[degenerates]] .= getproperty.(collect(row[interval_names[degenerates]]), :lb)
+            precise_df[1, interval_names[degenerates]] .=
+                getproperty.(collect(row[interval_names[degenerates]]), :lb)
         end
 
         function f(x)

--- a/src/models/slicingmodel.jl
+++ b/src/models/slicingmodel.jl
@@ -7,7 +7,7 @@ end
 
 # evaluates the transformed SNS problem
 function evaluate!(m::SlicingModel, df::DataFrame)
-    intervals = filter(x -> isa(x, Interval), m.inputs)
+    intervals = filter(x -> isa(x, IntervalVariable), m.inputs)
 
     physical = copy(df)
 

--- a/src/modelupdating/bayesianMAP.jl
+++ b/src/modelupdating/bayesianMAP.jl
@@ -12,7 +12,7 @@ Alternative constructors
 See also [`MaximumLikelihoodBayesian`](@ref), [`bayesianupdating `](@ref),  [`TransitionalMarkovChainMonteCarlo`](@ref).
 """
 struct MaximumAPosterioriBayesian <: AbstractBayesianPointEstimate
-    prior::Vector{RandomVariable}
+    prior::Vector{<:RandomVariable{<:UnivariateDistribution}}
     optimmethod::String
     x0::Vector{Vector{Float64}}
     islog::Bool
@@ -20,7 +20,7 @@ struct MaximumAPosterioriBayesian <: AbstractBayesianPointEstimate
     upperbounds::Vector{Float64}
 
     function MaximumAPosterioriBayesian(
-        prior::Vector{RandomVariable},
+        prior::Vector{<:RandomVariable{<:UnivariateDistribution}},
         optimmethod::String,
         x0::Vector{Float64};
         islog::Bool=true,
@@ -38,7 +38,7 @@ struct MaximumAPosterioriBayesian <: AbstractBayesianPointEstimate
     end
 
     function MaximumAPosterioriBayesian(
-        prior::Vector{RandomVariable},
+        prior::Vector{<:RandomVariable{<:UnivariateDistribution}},
         optimmethod::String,
         x0::Vector{Vector{Float64}};
         islog::Bool=true,
@@ -72,7 +72,7 @@ struct MaximumLikelihoodBayesian <: AbstractBayesianPointEstimate
 
     ## !TODO Currently the prior is used to get information about model parameters, maybe there is a better way. In MLE the prior is not needed
 
-    prior::Vector{RandomVariable}
+    prior::Vector{<:RandomVariable{<:UnivariateDistribution}}
     optimmethod::String
     x0::Vector{Vector{Float64}}
     islog::Bool
@@ -80,7 +80,7 @@ struct MaximumLikelihoodBayesian <: AbstractBayesianPointEstimate
     upperbounds::Vector{Float64}
 
     function MaximumLikelihoodBayesian(
-        prior::Vector{RandomVariable},
+        prior::Vector{<:RandomVariable{<:UnivariateDistribution}},
         optimmethod::String,
         x0::Vector{Float64};
         islog::Bool=true,
@@ -98,7 +98,7 @@ struct MaximumLikelihoodBayesian <: AbstractBayesianPointEstimate
     end
 
     function MaximumLikelihoodBayesian(
-        prior::Vector{RandomVariable},
+        prior::Vector{<:RandomVariable{<:UnivariateDistribution}},
         optimmethod::String,
         x0::Vector{Vector{Float64}};
         islog::Bool=true,

--- a/src/modelupdating/bayesianupdating.jl
+++ b/src/modelupdating/bayesianupdating.jl
@@ -149,14 +149,18 @@ Alternative constructors
 
 """
 struct TransitionalMarkovChainMonteCarlo <: AbstractBayesianMethod # Transitional Markov Chain Monte Carlo
-    prior::Vector{RandomVariable}
+    prior::Vector{<:RandomVariable{<:UnivariateDistribution}}
     n::Int
     burnin::Int
     β::Real
     islog::Bool
 
     function TransitionalMarkovChainMonteCarlo(
-        prior::Vector{RandomVariable}, n::Int, burnin::Int, β::Real=0.2, islog::Bool=true
+        prior::Vector{<:RandomVariable{<:UnivariateDistribution}},
+        n::Int,
+        burnin::Int,
+        β::Real=0.2,
+        islog::Bool=true,
     )
         if n <= 0
             error("Number of samples `n` must be positive")

--- a/src/reliability/probabilityoffailure_imprecise.jl
+++ b/src/reliability/probabilityoffailure_imprecise.jl
@@ -98,6 +98,17 @@ function map_to_precise_inputs(x::AbstractVector, inputs::AbstractVector{<:UQInp
             d = count(x -> isa(x, Interval), values(i.dist.parameters))
             p = [popfirst!(params) for _ in 1:d]
             push!(precise_inputs, map_to_precise(p, i))
+        elseif isa(i, JointDistribution)
+            precise_marginals = map(i.marginals) do rv
+                if isimprecise(rv)
+                    d = count(x -> isa(x, Interval), values(rv.dist.parameters))
+                    p = [popfirst!(params) for _ in 1:d]
+                    return map_to_precise(p, rv)
+                else
+                    return rv
+                end
+            end
+            push!(precise_inputs, JointDistribution(precise_marginals, i.copula))
         end
     end
     return precise_inputs

--- a/src/reliability/probabilityoffailure_imprecise.jl
+++ b/src/reliability/probabilityoffailure_imprecise.jl
@@ -70,7 +70,7 @@ function probability_of_failure(
     if pf_lb == pf_ub
         return pf_ub
     else
-        return Interval(pf_lb, pf_ub, :pf), result_lb.x, result_ub.x
+        return Interval(pf_lb, pf_ub), result_lb.x, result_ub.x
     end
 end
 
@@ -87,10 +87,10 @@ function map_to_precise_inputs(x::AbstractVector, inputs::AbstractVector{<:UQInp
     precise_inputs = UQInput[]
     params = collect(x)
     for i in inputs
-        if isa(i, Interval)
+        if isa(i, IntervalVariable)
             push!(precise_inputs, map_to_precise(popfirst!(params), i))
         elseif isa(i, RandomVariable{<:ProbabilityBox})
-            d = length(filter(x -> isa(x, Interval), i.dist.parameters))
+            d = count(x -> isa(x, Interval), values(i.dist.parameters))
             p = [popfirst!(params) for _ in 1:d]
             push!(precise_inputs, map_to_precise(p, i))
         end
@@ -120,7 +120,7 @@ function probability_of_failure(
 
     out_lb = probability_of_failure(sm_max, df -> df.g_slice, sns_inputs, rs.lb)
 
-    return Interval(out_lb[1], out_ub[1], :pf), out_lb[2:end], out_ub[2:end]
+    return Interval(out_lb[1], out_ub[1]), out_lb[2:end], out_ub[2:end]
 end
 
 function transform_to_sns_input(i::UQInput)

--- a/src/reliability/probabilityoffailure_imprecise.jl
+++ b/src/reliability/probabilityoffailure_imprecise.jl
@@ -1,9 +1,14 @@
-## 1st Method -  External: Global Opt ; Internal: Sampling
+
+"""
+    DoubleLoop(lb::AbstractSimulation, ub::AbstractSimulation)
+"""
 struct DoubleLoop
     lb::AbstractSimulation
     ub::AbstractSimulation
 end
-
+"""
+    RandomSlicing(lb::AbstractSimulation, ub::AbstractSimulation)
+"""
 struct RandomSlicing
     lb::AbstractSimulation
     ub::AbstractSimulation

--- a/src/sensitivity/gradient.jl
+++ b/src/sensitivity/gradient.jl
@@ -34,7 +34,14 @@ function gradient_in_standard_normal_space(
 )
     samples = copy(reference)
 
-    random_names = names(filter(i -> isa(i, RandomUQInput), inputs))
+    random_names = names(
+        filter(
+            i ->
+                isa(i, RandomVariable{<:UnivariateDistribution}) ||
+                    isa(i, JointDistribution),
+            inputs,
+        ),
+    )
 
     function f(x)
         samples[:, random_names] .= x

--- a/src/util/imprecise.jl
+++ b/src/util/imprecise.jl
@@ -3,5 +3,5 @@ function isimprecise(inputs::AbstractVector{<:UQInput})
 end
 
 function isimprecise(input::UQInput)
-    return isa(input, ImpreciseUQInput)
+    return isa(input, Interval) || isa(input, RandomVariable{<:ProbabilityBox})
 end

--- a/src/util/imprecise.jl
+++ b/src/util/imprecise.jl
@@ -3,5 +3,10 @@ function isimprecise(inputs::AbstractVector{<:UQInput})
 end
 
 function isimprecise(input::UQInput)
-    return isa(input, IntervalVariable) || isa(input, RandomVariable{<:ProbabilityBox})
+    return isa(input, IntervalVariable) ||
+           isa(input, RandomVariable{<:ProbabilityBox}) ||
+           (
+               isa(input, JointDistribution) &&
+               any(isa.(input.marginals, RandomVariable{<:ProbabilityBox}))
+           )
 end

--- a/src/util/imprecise.jl
+++ b/src/util/imprecise.jl
@@ -3,5 +3,5 @@ function isimprecise(inputs::AbstractVector{<:UQInput})
 end
 
 function isimprecise(input::UQInput)
-    return isa(input, Interval) || isa(input, RandomVariable{<:ProbabilityBox})
+    return isa(input, IntervalVariable) || isa(input, RandomVariable{<:ProbabilityBox})
 end

--- a/test/inputs/imprecise/interval.jl
+++ b/test/inputs/imprecise/interval.jl
@@ -3,12 +3,35 @@
     lb = 0.14
     ub = 0.16
     @test_throws ErrorException(
+        "Lower bound parameter must be smaller than upper bound parameter for Intervals."
+    ) Interval(ub, lb)
+    interval = Interval(lb, ub)
+    @test interval.lb == lb
+    @test interval.ub == ub
+
+    @test !(0.13 ∈ interval)
+    @test 0.14 ∈ interval
+    @test 0.15 ∈ interval
+    @test 0.16 ∈ interval
+    @test !(0.17 ∈ interval)
+end
+
+@testset "IntervalVariable" begin
+    name = :l
+    lb = 0.14
+    ub = 0.16
+    @test_throws ErrorException(
         "Lower bound parameter must be smaller than upper bound parameter for Interval $name.",
-    ) Interval(ub, lb, name)
-    interval = Interval(lb, ub, name)
+    ) IntervalVariable(ub, lb, name)
+    interval = IntervalVariable(lb, ub, name)
     @test interval.lb == lb
     @test interval.ub == ub
     @test interval.name == name
+    @test !(0.13 ∈ interval)
+    @test 0.14 ∈ interval
+    @test 0.15 ∈ interval
+    @test 0.16 ∈ interval
+    @test !(0.17 ∈ interval)
 
     par = 0.13
     @test_throws ErrorException("0.13 not in [0.14, 0.16] for Interval l.") UncertaintyQuantification.map_to_precise(
@@ -23,7 +46,7 @@
     @test UncertaintyQuantification.map_to_precise(0.15, interval) ==
         Parameter(0.15, interval.name)
 
-    interval = Interval(lb, ub, name)
+    interval = IntervalVariable(lb, ub, name)
 
-    @test UncertaintyQuantification.sample(interval) == DataFrame(; l=interval)
+    @test UncertaintyQuantification.sample(interval) == DataFrame(; l=Interval(interval))
 end

--- a/test/inputs/imprecise/interval.jl
+++ b/test/inputs/imprecise/interval.jl
@@ -50,7 +50,10 @@ end
     @test UncertaintyQuantification.map_to_precise(0.15, interval) ==
         Parameter(0.15, interval.name)
 
-    interval = IntervalVariable(lb, ub, name)
+    interval = IntervalVariable(0, 1, :x)
 
-    @test UncertaintyQuantification.sample(interval) == DataFrame(; l=Interval(interval))
+    @test mean(interval) == Interval(0, 1)
+    @test var(interval) == Interval(0.0, 0.25)
+
+    @test UncertaintyQuantification.sample(interval) == DataFrame(; x=Interval(interval))
 end

--- a/test/inputs/imprecise/interval.jl
+++ b/test/inputs/imprecise/interval.jl
@@ -14,6 +14,8 @@
     @test 0.15 ∈ interval
     @test 0.16 ∈ interval
     @test !(0.17 ∈ interval)
+
+    @test sprint(show, interval) == "[0.14, 0.16]"
 end
 
 @testset "IntervalVariable" begin
@@ -32,6 +34,8 @@ end
     @test 0.15 ∈ interval
     @test 0.16 ∈ interval
     @test !(0.17 ∈ interval)
+
+    @test sprint(show, interval) == "l ∈ [0.14, 0.16]"
 
     par = 0.13
     @test_throws ErrorException("0.13 not in [0.14, 0.16] for Interval l.") UncertaintyQuantification.map_to_precise(

--- a/test/inputs/imprecise/p-box.jl
+++ b/test/inputs/imprecise/p-box.jl
@@ -34,6 +34,14 @@
     @test p_box.lb == 0.0
     @test p_box.ub == Inf
     @test mean(p_box) == Interval(0.5, 0.75)
+    @test var(p_box) == Interval(0.25, 0.5625)
+
+    @test_logs (
+        :warn,
+        "ProbabilityBox() returns a UnivariateDistribution if no intervals are passed",
+    ) ProbabilityBox{Normal}(Dict(:μ => 0.0, :σ => 1.0))
+
+    @test ProbabilityBox{Normal}(Dict(:μ => 0.0, :σ => 1.0)) == Normal()
 
     @testset "Quantile and sampling" begin
         p_box = ProbabilityBox{Normal}(Dict(:μ => Interval(0, 1), :σ => Interval(0.1, 1)))

--- a/test/inputs/imprecise/p-box.jl
+++ b/test/inputs/imprecise/p-box.jl
@@ -43,6 +43,16 @@
 
     @test ProbabilityBox{Normal}(Dict(:μ => 0.0, :σ => 1.0)) == Normal()
 
+    @testset "Invalid distributions" begin
+        @test_throws ArgumentError(
+            "Invalid Normal distribution for parameter combination (0, -1)"
+        ) ProbabilityBox{Normal}(Dict(:μ => 0, :σ => Interval(-1, 1)))
+
+        @test_throws ArgumentError(
+            "Invalid Uniform distribution for parameter combination (0.16, 0.16)"
+        ) ProbabilityBox{Uniform}(Dict(:a => Interval(0.14, 0.16), :b => 0.16))
+    end
+
     @testset "Quantile and sampling" begin
         p_box = ProbabilityBox{Normal}(Dict(:μ => Interval(0, 1), :σ => Interval(0.1, 1)))
         a = UncertaintyQuantification.quantile(p_box, 0.25)

--- a/test/inputs/imprecise/p-box.jl
+++ b/test/inputs/imprecise/p-box.jl
@@ -1,39 +1,33 @@
 @testset "P-box" begin
-    name = :l
-
     params = [Interval(0.14, 0.16, :a), Interval(0.21, 0.23, :b), Interval(0, 1, :c)]
     @test_throws ErrorException(
-        "Parameter mismatch for ProbabilityBox l: [:a, :b, :c] != [:a, :b]."
-    ) ProbabilityBox{Uniform}(params, name)
+        "Parameter mismatch for ProbabilityBox [:a, :b, :c] != [:a, :b]."
+    ) ProbabilityBox{Uniform}(params)
 
     params = [Interval(0.14, 0.16, :a), Interval(0.21, 0.23, :b)]
 
-    p_box = ProbabilityBox{Uniform}(params, name)
+    p_box = ProbabilityBox{Uniform}(params)
     @test p_box.parameters == params
-    @test p_box.name == name
     @test p_box.lb == 0.14
     @test p_box.ub == 0.23
 
     @test UncertaintyQuantification.bounds(p_box) == ([0.14, 0.21], [0.16, 0.23])
 
     par = [0.13, 0.20]
-    @test_throws ErrorException(
-        "Values outside of parameter intervals for ProbabilityBox l."
-    ) UncertaintyQuantification.map_to_precise(par, p_box)
+    @test_throws ErrorException("Values outside of parameter intervals for ProbabilityBox") UncertaintyQuantification.map_to_distribution(
+        par, p_box
+    )
 
     par = [0.17, 0.25]
-    @test_throws ErrorException(
-        "Values outside of parameter intervals for ProbabilityBox l."
-    ) UncertaintyQuantification.map_to_precise(par, p_box)
+    @test_throws ErrorException("Values outside of parameter intervals for ProbabilityBox") UncertaintyQuantification.map_to_distribution(
+        par, p_box
+    )
 
     par = [0.15, 0.22]
-    @test UncertaintyQuantification.map_to_precise(par, p_box) ==
-        RandomVariable(Uniform(par...), p_box.name)
+    @test UncertaintyQuantification.map_to_distribution(par, p_box) == Uniform(par...)
 
     @testset "Quantile and sampling" begin
-        name = :l
-
-        p_box = ProbabilityBox{Normal}([Interval(0, 1, :μ), Interval(0.1, 1, :σ)], name)
+        p_box = ProbabilityBox{Normal}([Interval(0, 1, :μ), Interval(0.1, 1, :σ)])
         a = UncertaintyQuantification.quantile(p_box, 0.25)
         @test a.lb == quantile(Normal(0, 1), 0.25)
         @test a.ub == quantile(Normal(1, 0.1), 0.25)
@@ -48,7 +42,7 @@
         @test a.lb == quantile(Normal(0, 0.1), 0.75)
         @test a.ub == quantile(Normal(1, 1), 0.75)
 
-        p_box = ProbabilityBox{Normal}([Parameter(0, :μ), Interval(0.1, 1, :σ)], name)
+        p_box = ProbabilityBox{Normal}([Parameter(0, :μ), Interval(0.1, 1, :σ)])
         @test UncertaintyQuantification.bounds(p_box) == ([0.1], [1])
 
         a = UncertaintyQuantification.quantile(p_box, 0.25)
@@ -56,15 +50,15 @@
         @test a.ub == quantile(Normal(0, 0.1), 0.25)
 
         a = UncertaintyQuantification.quantile(p_box, 0.5)
-        @test a == Interval(0.0, 0.0, :l)
+        @test a == (lb=0.0, ub=0.0)
 
         a = UncertaintyQuantification.quantile(p_box, 0.75)
         @test a.lb == quantile(Normal(0, 0.1), 0.75)
         @test a.ub == quantile(Normal(0, 1), 0.75)
     end
 
-    @testset "Inverse quantile and transformations" begin
-        p_box = ProbabilityBox{Uniform}([Interval(0, 0.2, :a), Interval(0.5, 1, :b)], name)
+    @testset "Inverse quantile" begin
+        p_box = ProbabilityBox{Uniform}([Interval(0, 0.2, :a), Interval(0.5, 1, :b)])
 
         Nsamples = 1000
 
@@ -74,34 +68,5 @@
         u_back = UncertaintyQuantification.reverse_quantile.(Ref(p_box), x)
 
         @test all(abs.(u_back .- u) .<= 10^-10)
-
-        SNS_distribution = RandomVariable(Normal(0, 1), name)
-        SNS_samples = sample(SNS_distribution, Nsamples)
-
-        SNS_samples_before = deepcopy(SNS_samples)
-
-        to_physical_space!(p_box, SNS_samples)
-        to_standard_normal_space!(p_box, SNS_samples)
-
-        @test all(abs.(SNS_samples[!, :l] .- SNS_samples_before[!, :l]) .<= 10^-10)
-
-        p_box = ProbabilityBox{Uniform}([Interval(0, 0.2, :a), Parameter(1, :b)], name)
-
-        u = rand(Nsamples)
-        x = quantile.(Ref(p_box), u)
-
-        u_back = UncertaintyQuantification.reverse_quantile.(Ref(p_box), x)
-
-        @test all(abs.(u_back .- u) .<= 10^-10)
-
-        SNS_distribution = RandomVariable(Normal(0, 1), name)
-        SNS_samples = sample(SNS_distribution, Nsamples)
-
-        SNS_samples_before = deepcopy(SNS_samples)
-
-        to_physical_space!(p_box, SNS_samples)
-        to_standard_normal_space!(p_box, SNS_samples)
-
-        @test all(abs.(SNS_samples[!, :l] .- SNS_samples_before[!, :l]) .<= 10^-10)
     end
 end

--- a/test/inputs/imprecise/p-box.jl
+++ b/test/inputs/imprecise/p-box.jl
@@ -16,17 +16,17 @@
     @test UncertaintyQuantification.bounds(p_box) == ([0.14, 0.21], [0.16, 0.23])
 
     par = [0.13, 0.20]
-    @test_throws ErrorException("Values outside of parameter intervals for ProbabilityBox") UncertaintyQuantification.map_to_distribution(
+    @test_throws ErrorException("Values outside of parameter intervals for ProbabilityBox") UncertaintyQuantification.map_to_precise(
         par, p_box
     )
 
     par = [0.17, 0.25]
-    @test_throws ErrorException("Values outside of parameter intervals for ProbabilityBox") UncertaintyQuantification.map_to_distribution(
+    @test_throws ErrorException("Values outside of parameter intervals for ProbabilityBox") UncertaintyQuantification.map_to_precise(
         par, p_box
     )
 
     par = [0.15, 0.22]
-    @test UncertaintyQuantification.map_to_distribution(par, p_box) == Uniform(par...)
+    @test UncertaintyQuantification.map_to_precise(par, p_box) == Uniform(par...)
 
     @testset "Quantile and sampling" begin
         p_box = ProbabilityBox{Normal}(Dict(:μ => Interval(0, 1), :σ => Interval(0.1, 1)))

--- a/test/inputs/imprecise/p-box.jl
+++ b/test/inputs/imprecise/p-box.jl
@@ -12,6 +12,7 @@
     @test p_box.parameters == params
     @test p_box.lb == 0.14
     @test p_box.ub == 0.23
+    @test mean(p_box) == Interval(0.175, 0.195)
 
     @test UncertaintyQuantification.bounds(p_box) == ([0.14, 0.21], [0.16, 0.23])
 
@@ -27,6 +28,12 @@
 
     par = [0.15, 0.22]
     @test UncertaintyQuantification.map_to_precise(par, p_box) == Uniform(par...)
+
+    p_box = ProbabilityBox{Exponential}(Interval(0.5, 0.75))
+    @test p_box.parameters == Dict{Symbol,Interval}(:θ => Interval(0.5, 0.75))
+    @test p_box.lb == 0.0
+    @test p_box.ub == Inf
+    @test mean(p_box) == Interval(0.5, 0.75)
 
     @testset "Quantile and sampling" begin
         p_box = ProbabilityBox{Normal}(Dict(:μ => Interval(0, 1), :σ => Interval(0.1, 1)))

--- a/test/inputs/imprecise/p-box.jl
+++ b/test/inputs/imprecise/p-box.jl
@@ -1,10 +1,12 @@
 @testset "P-box" begin
-    params = [Interval(0.14, 0.16, :a), Interval(0.21, 0.23, :b), Interval(0, 1, :c)]
+    params = Dict(
+        :a => Interval(0.14, 0.16), :b => Interval(0.21, 0.23), :c => Interval(0, 1)
+    )
     @test_throws ErrorException(
         "Parameter mismatch for ProbabilityBox [:a, :b, :c] != [:a, :b]."
     ) ProbabilityBox{Uniform}(params)
 
-    params = [Interval(0.14, 0.16, :a), Interval(0.21, 0.23, :b)]
+    params = Dict(:a => Interval(0.14, 0.16), :b => Interval(0.21, 0.23))
 
     p_box = ProbabilityBox{Uniform}(params)
     @test p_box.parameters == params
@@ -27,7 +29,7 @@
     @test UncertaintyQuantification.map_to_distribution(par, p_box) == Uniform(par...)
 
     @testset "Quantile and sampling" begin
-        p_box = ProbabilityBox{Normal}([Interval(0, 1, :μ), Interval(0.1, 1, :σ)])
+        p_box = ProbabilityBox{Normal}(Dict(:μ => Interval(0, 1), :σ => Interval(0.1, 1)))
         a = UncertaintyQuantification.quantile(p_box, 0.25)
         @test a.lb == quantile(Normal(0, 1), 0.25)
         @test a.ub == quantile(Normal(1, 0.1), 0.25)
@@ -42,7 +44,7 @@
         @test a.lb == quantile(Normal(0, 0.1), 0.75)
         @test a.ub == quantile(Normal(1, 1), 0.75)
 
-        p_box = ProbabilityBox{Normal}([Parameter(0, :μ), Interval(0.1, 1, :σ)])
+        p_box = ProbabilityBox{Normal}(Dict(:μ => 0, :σ => Interval(0.1, 1)))
         @test UncertaintyQuantification.bounds(p_box) == ([0.1], [1])
 
         a = UncertaintyQuantification.quantile(p_box, 0.25)
@@ -50,7 +52,7 @@
         @test a.ub == quantile(Normal(0, 0.1), 0.25)
 
         a = UncertaintyQuantification.quantile(p_box, 0.5)
-        @test a == (lb=0.0, ub=0.0)
+        @test a == Interval(0.0, 0.0)
 
         a = UncertaintyQuantification.quantile(p_box, 0.75)
         @test a.lb == quantile(Normal(0, 0.1), 0.75)
@@ -58,7 +60,9 @@
     end
 
     @testset "Inverse quantile" begin
-        p_box = ProbabilityBox{Uniform}([Interval(0, 0.2, :a), Interval(0.5, 1, :b)])
+        p_box = ProbabilityBox{Uniform}(
+            Dict(:a => Interval(0, 0.2), :b => Interval(0.5, 1))
+        )
 
         Nsamples = 1000
 

--- a/test/inputs/randomvariables/randomvariable.jl
+++ b/test/inputs/randomvariables/randomvariable.jl
@@ -62,5 +62,21 @@
 
             @test samples.x ≈ mapped.x
         end
+
+        @testset "ProbabilityBox" begin
+            p_box = RandomVariable(
+                ProbabilityBox{Uniform}([Interval(0, 0.2, :a), Interval(0.5, 1, :b)]), :l
+            )
+
+            SNS_distribution = RandomVariable(Normal(0, 1), :l)
+            SNS_samples = sample(SNS_distribution, 1000)
+
+            SNS_samples_before = deepcopy(SNS_samples)
+
+            to_physical_space!(p_box, SNS_samples)
+            to_standard_normal_space!(p_box, SNS_samples)
+
+            @test all(abs.(SNS_samples[!, :l] .- SNS_samples_before[!, :l]) .<= 10^-10)
+        end
     end
 end

--- a/test/inputs/randomvariables/randomvariable.jl
+++ b/test/inputs/randomvariables/randomvariable.jl
@@ -65,7 +65,10 @@
 
         @testset "ProbabilityBox" begin
             p_box = RandomVariable(
-                ProbabilityBox{Uniform}([Interval(0, 0.2, :a), Interval(0.5, 1, :b)]), :l
+                ProbabilityBox{Uniform}(
+                    Dict(:a => Interval(0, 0.2), :b => Interval(0.5, 1))
+                ),
+                :l,
             )
 
             SNS_distribution = RandomVariable(Normal(0, 1), :l)

--- a/test/models/imprecise/propagation.jl
+++ b/test/models/imprecise/propagation.jl
@@ -1,10 +1,6 @@
 @testset "Interval propagation" begin
-    X1 = RandomVariable(
-        ProbabilityBox{Normal}([Interval(-1, 2, :μ), Parameter(1, :σ)]), :X1
-    )
-    X2 = RandomVariable(
-        ProbabilityBox{Normal}([Interval(-2, 1, :μ), Parameter(2, :σ)]), :X2
-    )
+    X1 = RandomVariable(ProbabilityBox{Normal}(Dict(:μ => Interval(-1, 2), :σ => 1)), :X1)
+    X2 = RandomVariable(ProbabilityBox{Normal}(Dict(:μ => Interval(-2, 1), :σ => 2)), :X2)
     X3 = RandomVariable(Normal(0, 1), :X3)
     X4 = Parameter(5, :X4)
 

--- a/test/models/imprecise/propagation.jl
+++ b/test/models/imprecise/propagation.jl
@@ -1,6 +1,10 @@
 @testset "Interval propagation" begin
-    X1 = ProbabilityBox{Normal}([Interval(-1, 2, :μ), Parameter(1, :σ)], :X1)
-    X2 = ProbabilityBox{Normal}([Interval(-2, 1, :μ), Parameter(2, :σ)], :X2)
+    X1 = RandomVariable(
+        ProbabilityBox{Normal}([Interval(-1, 2, :μ), Parameter(1, :σ)]), :X1
+    )
+    X2 = RandomVariable(
+        ProbabilityBox{Normal}([Interval(-2, 1, :μ), Parameter(2, :σ)]), :X2
+    )
     X3 = RandomVariable(Normal(0, 1), :X3)
     X4 = Parameter(5, :X4)
 

--- a/test/reliability/probabilityoffailure_imprecise.jl
+++ b/test/reliability/probabilityoffailure_imprecise.jl
@@ -2,10 +2,12 @@
     @testset "Double Loop" begin
         @testset "P-boxes only" begin
             X = RandomVariable(
-                ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)]), :X
+                ProbabilityBox{Normal}(Dict(:μ => Interval(-1, 1), :σ => Interval(1, 2))),
+                :X,
             )
             Y = RandomVariable(
-                ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)]), :Y
+                ProbabilityBox{Normal}(Dict(:μ => Interval(-1, 1), :σ => Interval(1, 2))),
+                :Y,
             )
 
             pf, x_lb, x_ub = probability_of_failure(
@@ -17,7 +19,7 @@
         end
 
         @testset "Interval - Distribution" begin
-            X = Interval(-1, 1, :X)
+            X = IntervalVariable(-1, 1, :X)
             Y = RandomVariable(Normal(0, 2), :Y)
 
             pf, x_lb, x_ub = probability_of_failure(
@@ -30,7 +32,8 @@
 
         @testset "P-box - Distribution" begin
             X = RandomVariable(
-                ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)]), :X
+                ProbabilityBox{Normal}(Dict(:μ => Interval(-1, 1), :σ => Interval(1, 2))),
+                :X,
             )
             Y = RandomVariable(Normal(0, 2), :Y)
 
@@ -43,9 +46,9 @@
         end
 
         @testset "Interval - p-box" begin
-            X = Interval(-1, 1, :X)
+            X = IntervalVariable(-1, 1, :X)
             Y = RandomVariable(
-                ProbabilityBox{Normal}([Parameter(0, :μ), Interval(1, 2, :σ)]), :Y
+                ProbabilityBox{Normal}(Dict(:μ => 0, :σ => Interval(1, 2))), :Y
             )
 
             pf, x_lb, x_ub = probability_of_failure(
@@ -63,19 +66,21 @@
     @testset "Random Slicing" begin
         @testset "P-boxes only" begin
             X = RandomVariable(
-                ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)]), :X
+                ProbabilityBox{Normal}(Dict(:μ => Interval(-1, 1), :σ => Interval(1, 2))),
+                :X,
             )
             Y = RandomVariable(
-                ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)]), :Y
+                ProbabilityBox{Normal}(Dict(:μ => Interval(-1, 1), :σ => Interval(1, 2))),
+                :Y,
             )
 
             pf, _ = probability_of_failure(
                 UQModel[], df -> 9 .+ df.X .+ df.Y, [X, Y], RandomSlicing(FORM())
             )
 
-            pbox_analyt = ProbabilityBox{Normal}([
-                Interval(-2, 2, :μ), Interval(sqrt(2), sqrt(8), :σ)
-            ])
+            pbox_analyt = ProbabilityBox{Normal}(
+                Dict(:μ => Interval(-2, 2), :σ => Interval(sqrt(2), sqrt(8)))
+            )
             failure_analty = cdf(pbox_analyt, -9)
 
             @test pf.lb ≈ failure_analty.lb atol = 1e-6
@@ -83,14 +88,14 @@
         end
 
         @testset "Interval - Distribution" begin
-            X = Interval(-1, 1, :X)
+            X = IntervalVariable(-1, 1, :X)
             Y = RandomVariable(Normal(0, 2), :Y)
 
             pf, _ = probability_of_failure(
                 UQModel[], df -> 9 .+ df.X .+ df.Y, [X, Y], RandomSlicing(FORM())
             )
 
-            pbox_analyt = ProbabilityBox{Normal}([Interval(-1, 1, :μ), Parameter(2, :σ)])
+            pbox_analyt = ProbabilityBox{Normal}(Dict(:μ => Interval(-1, 1), :σ => 2))
             failure_analty = cdf(pbox_analyt, -9)
 
             @test pf.lb ≈ failure_analty.lb atol = 1e-6
@@ -99,7 +104,8 @@
 
         @testset "P-box - Distribution" begin
             X = RandomVariable(
-                ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)]), :X
+                ProbabilityBox{Normal}(Dict(:μ => Interval(-1, 1), :σ => Interval(1, 2))),
+                :X,
             )
             Y = RandomVariable(Normal(0, 2), :Y)
 
@@ -107,9 +113,9 @@
                 UQModel[], df -> 9 .+ df.X .+ df.Y, [X, Y], RandomSlicing(FORM())
             )
 
-            pbox_analyt = ProbabilityBox{Normal}([
-                Interval(-1, 1, :μ), Interval(sqrt(5), sqrt(8), :σ)
-            ])
+            pbox_analyt = ProbabilityBox{Normal}(
+                Dict(:μ => Interval(-1, 1), :σ => Interval(sqrt(5), sqrt(8)))
+            )
             failure_analty = cdf(pbox_analyt, -9)
 
             @test pf.lb ≈ cdf(Normal(1, sqrt(5)), -9) atol = 1e-6
@@ -117,16 +123,18 @@
         end
 
         @testset "Interval - p-box" begin
-            X = Interval(-1, 1, :X)
+            X = IntervalVariable(-1, 1, :X)
             Y = RandomVariable(
-                ProbabilityBox{Normal}([Parameter(0, :μ), Interval(1, 2, :σ)]), :Y
+                ProbabilityBox{Normal}(Dict(:μ => 0, :σ => Interval(1, 2))), :Y
             )
 
             pf, _ = probability_of_failure(
                 UQModel[], df -> 9 .+ df.X .+ df.Y, [X, Y], RandomSlicing(FORM())
             )
 
-            pbox_analyt = ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)])
+            pbox_analyt = ProbabilityBox{Normal}(
+                Dict(:μ => Interval(-1, 1), :σ => Interval(1, 2))
+            )
             failure_analty = cdf(pbox_analyt, -9)
 
             @test pf.lb ≈ failure_analty.lb atol = 1e-6

--- a/test/reliability/probabilityoffailure_imprecise.jl
+++ b/test/reliability/probabilityoffailure_imprecise.jl
@@ -18,6 +18,28 @@
             @test pf.ub ≈ cdf(Normal(-2, sqrt(8)), -9) atol = 1e-6
         end
 
+        @testset "P-boxes with Copula" begin
+            X = RandomVariable(
+                ProbabilityBox{Normal}(Dict(:μ => Interval(-1, 1), :σ => Interval(1, 2))),
+                :X,
+            )
+            Y = RandomVariable(
+                ProbabilityBox{Normal}(Dict(:μ => Interval(-1, 1), :σ => Interval(1, 2))),
+                :Y,
+            )
+
+            c = GaussianCopula([1 0.0; 0.0 1])
+
+            jd = JointDistribution([X, Y], c)
+
+            pf, x_lb, x_ub = probability_of_failure(
+                UQModel[], df -> 9 .+ df.X .+ df.Y, jd, DoubleLoop(FORM())
+            )
+
+            @test pf.lb ≈ cdf(Normal(2, sqrt(2)), -9) atol = 1e-6
+            @test pf.ub ≈ cdf(Normal(-2, sqrt(8)), -9) atol = 1e-6
+        end
+
         @testset "Interval - Distribution" begin
             X = IntervalVariable(-1, 1, :X)
             Y = RandomVariable(Normal(0, 2), :Y)
@@ -76,6 +98,34 @@
 
             pf, _ = probability_of_failure(
                 UQModel[], df -> 9 .+ df.X .+ df.Y, [X, Y], RandomSlicing(FORM())
+            )
+
+            pbox_analyt = ProbabilityBox{Normal}(
+                Dict(:μ => Interval(-2, 2), :σ => Interval(sqrt(2), sqrt(8)))
+            )
+            failure_analty = cdf(pbox_analyt, -9)
+
+            @test pf.lb ≈ failure_analty.lb atol = 1e-6
+            @test pf.ub ≈ failure_analty.ub atol = 1e-6
+        end
+
+        @testset "P-boxes with Copula" begin
+            X = RandomVariable(
+                ProbabilityBox{Normal}(Dict(:μ => Interval(-1, 1), :σ => Interval(1, 2))),
+                :X,
+            )
+            Y = RandomVariable(
+                ProbabilityBox{Normal}(Dict(:μ => Interval(-1, 1), :σ => Interval(1, 2))),
+                :Y,
+            )
+
+            # independent so the solution is the same
+            c = GaussianCopula([1 0.0; 0.0 1])
+
+            jd = JointDistribution([X, Y], c)
+
+            pf, _ = probability_of_failure(
+                UQModel[], df -> 9 .+ df.X .+ df.Y, jd, RandomSlicing(FORM())
             )
 
             pbox_analyt = ProbabilityBox{Normal}(

--- a/test/reliability/probabilityoffailure_imprecise.jl
+++ b/test/reliability/probabilityoffailure_imprecise.jl
@@ -1,8 +1,12 @@
 @testset "Imprecise Probability of Failure" begin
     @testset "Double Loop" begin
         @testset "P-boxes only" begin
-            X = ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)], :X)
-            Y = ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)], :Y)
+            X = RandomVariable(
+                ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)]), :X
+            )
+            Y = RandomVariable(
+                ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)]), :Y
+            )
 
             pf, x_lb, x_ub = probability_of_failure(
                 UQModel[], df -> 9 .+ df.X .+ df.Y, [X, Y], DoubleLoop(FORM())
@@ -25,7 +29,9 @@
         end
 
         @testset "P-box - Distribution" begin
-            X = ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)], :X)
+            X = RandomVariable(
+                ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)]), :X
+            )
             Y = RandomVariable(Normal(0, 2), :Y)
 
             pf, x_lb, x_ub = probability_of_failure(
@@ -38,7 +44,9 @@
 
         @testset "Interval - p-box" begin
             X = Interval(-1, 1, :X)
-            Y = ProbabilityBox{Normal}([Parameter(0, :μ), Interval(1, 2, :σ)], :Y)
+            Y = RandomVariable(
+                ProbabilityBox{Normal}([Parameter(0, :μ), Interval(1, 2, :σ)]), :Y
+            )
 
             pf, x_lb, x_ub = probability_of_failure(
                 UQModel[], df -> 9 .+ df.X .+ df.Y, [X, Y], DoubleLoop(FORM())
@@ -54,16 +62,20 @@
 
     @testset "Random Slicing" begin
         @testset "P-boxes only" begin
-            X = ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)], :X)
-            Y = ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)], :Y)
+            X = RandomVariable(
+                ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)]), :X
+            )
+            Y = RandomVariable(
+                ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)]), :Y
+            )
 
             pf, _ = probability_of_failure(
                 UQModel[], df -> 9 .+ df.X .+ df.Y, [X, Y], RandomSlicing(FORM())
             )
 
-            pbox_analyt = ProbabilityBox{Normal}(
-                [Interval(-2, 2, :μ), Interval(sqrt(2), sqrt(8), :σ)], :X
-            )
+            pbox_analyt = ProbabilityBox{Normal}([
+                Interval(-2, 2, :μ), Interval(sqrt(2), sqrt(8), :σ)
+            ])
             failure_analty = cdf(pbox_analyt, -9)
 
             @test pf.lb ≈ failure_analty.lb atol = 1e-6
@@ -78,9 +90,7 @@
                 UQModel[], df -> 9 .+ df.X .+ df.Y, [X, Y], RandomSlicing(FORM())
             )
 
-            pbox_analyt = ProbabilityBox{Normal}(
-                [Interval(-1, 1, :μ), Parameter(2, :σ)], :X
-            )
+            pbox_analyt = ProbabilityBox{Normal}([Interval(-1, 1, :μ), Parameter(2, :σ)])
             failure_analty = cdf(pbox_analyt, -9)
 
             @test pf.lb ≈ failure_analty.lb atol = 1e-6
@@ -88,16 +98,18 @@
         end
 
         @testset "P-box - Distribution" begin
-            X = ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)], :X)
+            X = RandomVariable(
+                ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)]), :X
+            )
             Y = RandomVariable(Normal(0, 2), :Y)
 
             pf, _ = probability_of_failure(
                 UQModel[], df -> 9 .+ df.X .+ df.Y, [X, Y], RandomSlicing(FORM())
             )
 
-            pbox_analyt = ProbabilityBox{Normal}(
-                [Interval(-1, 1, :μ), Interval(sqrt(5), sqrt(8), :σ)], :X
-            )
+            pbox_analyt = ProbabilityBox{Normal}([
+                Interval(-1, 1, :μ), Interval(sqrt(5), sqrt(8), :σ)
+            ])
             failure_analty = cdf(pbox_analyt, -9)
 
             @test pf.lb ≈ cdf(Normal(1, sqrt(5)), -9) atol = 1e-6
@@ -106,15 +118,15 @@
 
         @testset "Interval - p-box" begin
             X = Interval(-1, 1, :X)
-            Y = ProbabilityBox{Normal}([Parameter(0, :μ), Interval(1, 2, :σ)], :Y)
+            Y = RandomVariable(
+                ProbabilityBox{Normal}([Parameter(0, :μ), Interval(1, 2, :σ)]), :Y
+            )
 
             pf, _ = probability_of_failure(
                 UQModel[], df -> 9 .+ df.X .+ df.Y, [X, Y], RandomSlicing(FORM())
             )
 
-            pbox_analyt = ProbabilityBox{Normal}(
-                [Interval(-1, 1, :μ), Interval(1, 2, :σ)], :X
-            )
+            pbox_analyt = ProbabilityBox{Normal}([Interval(-1, 1, :μ), Interval(1, 2, :σ)])
             failure_analty = cdf(pbox_analyt, -9)
 
             @test pf.lb ≈ failure_analty.lb atol = 1e-6


### PR DESCRIPTION
This PR introduces two main changes:

1. The `ProbabilityBox` is now without `name` and has to be wrapped inside a `RandomVariable` (now a parametric type)
 - Additionally, a pbox is now constructed using a Dictionary mapping the parameters of the distribution to either a `Real` or a `Interval`
 - I think this is a lot cleaner than before and also easier to handle in the code. 
3. The `Interval` type is now mainly used internally for the propagation of epistemic uncertainties and to construct p-boxes
 - A new `IntervalVariable`  is introduced to be used as inputs

This gives us more flexibility and allows us to use intervals and pboxes inside other structs in downstream packages.

As an added benefit this gives us dependent pboxes.

I've also added documentation on imprecise reliability analysis.

Closes #196