### PR TITLE
Weighted Approximate Feteke Points

### DIFF
--- a/demo/metamodels/polynomialchaosexpansion.jl
+++ b/demo/metamodels/polynomialchaosexpansion.jl
@@ -43,10 +43,12 @@ evaluate!(model, samplesMC)
 println("MC Mean: $(mean(samplesMC.y))")
 println("MC Variance: $(var(samplesMC.y))")
 
-# Plots 3 histograms
+# Plots 4 histograms
 samplesLS = sample(pceLS, 10^5)
+samplesWAFP = sample(pceWAFP, 10^5)
 samplesGQ = sample(pceGQ, 10^5)
 
 histogram(samplesLS.y; alpha=0.5, label="Least squares", normalize=:probability, bins=100)
+histogram!(samplesWAFP.y; alpha=0.5, label="WAFP", normalize=:probability, bins=100)
 histogram!(samplesGQ.y; alpha=0.5, label="Quadrature", normalize=:probability, bins=100)
 histogram!(samplesMC.y; alpha=0.5, label="Monte Carlo", normalize=:probability, bins=100)

--- a/demo/metamodels/polynomialchaosexpansion.jl
+++ b/demo/metamodels/polynomialchaosexpansion.jl
@@ -21,10 +21,10 @@ println("--------------------------")
 
 # Estimation by WAFP
 wafp = WeightedApproximateFetekePoints(SobolSampling(ls_n))
-pceLS, samples, mse = polynomialchaos(x, model, Ψ, :y, wafp)
+pceWAFP, samples, mse = polynomialchaos(x, model, Ψ, :y, wafp)
 
-println("WAFP Mean: $(mean(pceLS))")
-println("WAFP Variance: $(var(pceLS))")
+println("WAFP Mean: $(mean(pceWAFP))")
+println("WAFP Variance: $(var(pceWAFP))")
 println("WAFP Mean Squared Error: $mse")
 println("--------------------------")
 

--- a/demo/metamodels/polynomialchaosexpansion.jl
+++ b/demo/metamodels/polynomialchaosexpansion.jl
@@ -19,6 +19,15 @@ println("LS Variance: $(var(pceLS))")
 println("LS Mean Squared Error: $mse")
 println("--------------------------")
 
+# Estimation by WAFP
+wafp = WeightedApproximateFetekePoints(SobolSampling(ls_n))
+pceLS, samples, mse = polynomialchaos(x, model, Ψ, :y, wafp)
+
+println("WAFP Mean: $(mean(pceLS))")
+println("WAFP Variance: $(var(pceLS))")
+println("WAFP Mean Squared Error: $mse")
+println("--------------------------")
+
 # Estimation by full quadrature
 gq = GaussQuadrature()
 pceGQ, samples = polynomialchaos(x, model, Ψ, :y, gq)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -62,6 +62,7 @@ makedocs(;
             "Power Spectral Density Functions" => "api/psd.md",
             "Stochastic Processes (Spectral Representation)" => "api/spectralrepresentation.md",
             "SlurmInterface" => "api/slurm.md",
+            "Polynomial Chaos Expansions" => "api/polynomialchaos.md",
         ],
         "References" => "references.md",
     ],

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -391,9 +391,18 @@
   doi        = {10.1007/978-3-642-36197-5_165-1},
   langid     = {english}
 }
-<<<<<<< HEAD
 
-
-
-=======
->>>>>>> master
+@article{burkEfficientSampling,
+  author = {Burk, Kyle M. and Narayan, Akil and Orr, Joseph A.},
+  title = {Efficient sampling for polynomial chaos-based uncertainty quantification and sensitivity analysis using weighted approximate Fekete points},
+  journal = {International Journal for Numerical Methods in Biomedical Engineering},
+  volume = {36},
+  number = {11},
+  pages = {e3395},
+  keywords = {approximate Fekete points, cardiovascular modeling, oxyhemoglobin dissociation, polynomial chaos expansion, sensitivity analysis, uncertainty quantification},
+  doi = {https://doi.org/10.1002/cnm.3395},
+  url = {https://onlinelibrary.wiley.com/doi/abs/10.1002/cnm.3395},
+  eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/cnm.3395},
+  abstract = {Abstract Performing uncertainty quantification (UQ) and sensitivity analysis (SA) is vital when developing a patient-specific physiological model because it can quantify model output uncertainty and estimate the effect of each of the model's input parameters on the mathematical model. By providing this information, UQ and SA act as diagnostic tools to evaluate model fidelity and compare model characteristics with expert knowledge and real world observation. Computational efficiency is an important part of UQ and SA methods and thus optimization is an active area of research. In this work, we investigate a new efficient sampling method for least-squares polynomial approximation, weighted approximate Fekete points (WAFP). We analyze the performance of this method by demonstrating its utility in stochastic analysis of a cardiovascular model that estimates changes in oxyhemoglobin saturation response. Polynomial chaos (PC) expansion using WAFP produced results similar to the more standard Monte Carlo in quantifying uncertainty and identifying the most influential model inputs (including input interactions) when modeling oxyhemoglobin saturation, PC expansion using WAFP was far more efficient. These findings show the usefulness of using WAFP based PC expansion to quantify uncertainty and analyze sensitivity of a oxyhemoglobin dissociation response model. Applying these techniques could help analyze the fidelity of other relevant models in preparation for clinical application.},
+  year = {2020}
+}

--- a/docs/src/api/polynomialchaos.md
+++ b/docs/src/api/polynomialchaos.md
@@ -1,0 +1,13 @@
+# Polynomial Chaos Expansion
+
+## Index
+
+```@index
+Pages = ["polynomialchaos.md"]
+```
+
+## Types
+
+```@docs
+WeightedApproximateFetekePoints
+```

--- a/src/UncertaintyQuantification.jl
+++ b/src/UncertaintyQuantification.jl
@@ -116,6 +116,7 @@ export KanaiTajimi
 export LatinHypercubeSampling
 export LatticeRuleSampling
 export LeastSquares
+export WeightedApproximateFetekePoints
 export LegendreBasis
 export LineSampling
 export SingleComponentMetropolisHastings

--- a/src/models/pce/polynomialchaosexpansion.jl
+++ b/src/models/pce/polynomialchaosexpansion.jl
@@ -15,9 +15,7 @@ end
 Struct for performing weighted approximate Feteke points (wafp) subsampling of a Monte-Carlo sampler for use in generating a 
 `PolynomialChaosExpansion`. Given a `PolynomialChaosBasis` of dimension `N`, and a Monte-Carlo sampler with `M` samples, generates
 a subsample of size `max(N,min(N+fadd,N+fmult,M))` biased towards maximizing the determinant of the Gramian typically requiring less 
-than `M` model evaluations. Follows the strategy outlined in paper:
-
-Burk, Narayan, Orr; https://arxiv.org/abs/2008.04854
+than `M` model evaluations. Follows procedure described in [burkEfficientSampling](@cite). 
 """
 struct WeightedApproximateFetekePoints
     sim::AbstractMonteCarlo

--- a/src/models/pce/polynomialchaosexpansion.jl
+++ b/src/models/pce/polynomialchaosexpansion.jl
@@ -9,14 +9,23 @@ struct LeastSquares
     sim::AbstractMonteCarlo
 end
 
+"""
+    WeightedApproximateFetekePoints(sim::AbstractMonteCarlo; fadd=10, fmult=2)
+
+Struct for performing weighted approximate Feteke points (wafp) subsampling of a Monte-Carlo sampler for use in generating a 
+`PolynomialChaosExpansion`. Given a `PolynomialChaosBasis` of dimension `N`, and a Monte-Carlo sampler with `M` samples, generates
+a subsample of size `max(N,min(N+fadd,N+fmult,M))` biased towards maximizing the determinant of the Gramian typically requiring less 
+than `M` model evaluations. Follows the strategy outlined in paper:
+
+Burk, Narayan, Orr; https://arxiv.org/abs/2008.04854
+"""
 struct WeightedApproximateFetekePoints
     sim::AbstractMonteCarlo
     fadd::Integer
     fmult::Integer
-end
-
-function WeightedApproximateFetekePoints(sim::AbstractMonteCarlo; fadd=10, fmult=2)
-    return WeightedApproximateFetekePoints(sim, fadd, fmult)
+    function WeightedApproximateFetekePoints(sim::AbstractMonteCarlo; fadd=10, fmult=2)
+        return new(sim, fadd, fmult)
+    end
 end
 
 struct GaussQuadrature end

--- a/test/models/pce/polynomialchaosexpansion.jl
+++ b/test/models/pce/polynomialchaosexpansion.jl
@@ -27,6 +27,19 @@
         @test mse ≈ ϵ atol = eps()
     end
 
+    @testset "WeightedApproximateFetekePoints" begin
+        wafp = WeightedApproximateFetekePoints(SobolSampling(1000))
+        pce, samples, mse = polynomialchaos(x, model, Ψ, :y, wafp)
+
+        new_samples = samples[:, Not(:y1, :y)]
+        evaluate!(pce, new_samples)
+        ϵ = mean((new_samples.y .- samples.y) .^ 2)
+
+        @test mean(pce) ≈ -1.5 rtol = 1e-10
+        @test var(pce) ≈ 0.5 rtol = 1e-10
+        @test mse ≈ ϵ atol = eps()
+    end
+
     @testset "GaussQuadrature" begin
         gq = GaussQuadrature()
         pce, _ = polynomialchaos(x, model, Ψ, :y, gq)


### PR DESCRIPTION
This is one of the suggestions provided in [Issue 251](https://github.com/FriesischScott/UncertaintyQuantification.jl/issues/251) regarding adding weighted approximate Feteke points (wafp) sampling to the `polynomialchaosexpansion` method. This method relies on a Monte-Carlo sample of parameters and a `PolynomialChaosBasis` and generates a sparse subsample of those on which to evaluate the model. The points are chosen in a manner to form a Gram matrix with a low condition number which is less numerically unstable to invert. See the following paper for more details:

[Efficient sampling for polynomial chaos-based uncertainty quantification and sensitivity analysis using weighted approximate Fekete points](https://arxiv.org/abs/2008.04854)

The result is a small number of model evaluations required to form the PCE which is helpful when the model is expensive to run. Wafp is dependent on two parameters: `fadd` and `fmult`, which I have stored as variables of the `WeightedApproximateFetekePoints` struct. If the `PolynomialChaosBasis` has `N` multi-indices, the wafp method requires `min(N+fadd,N*fmult,n)` model evaluations where `n` is the size of the Monte-Carlo sample. These parameters are defaulted to `fadd=10`, `fmult=2` as in the paper, but may require per-model tuning.