### PR TITLE
correction for empty string as extra file for ExternalModel

### DIFF
--- a/src/models/external/externalmodel.jl
+++ b/src/models/external/externalmodel.jl
@@ -68,6 +68,9 @@ function makedirectory(m::ExternalModel, sample, path::String)
     end
 
     for file in m.extras
+        if isempty(file)
+            continue
+        end
         cp(joinpath(m.sourcedir, file), joinpath(path, file))
     end
     return nothing

--- a/test/models/external/externalmodel.jl
+++ b/test/models/external/externalmodel.jl
@@ -68,6 +68,21 @@ include("../../test_utilities/read_write_utils.jl")
         result = UncertaintyQuantification.getresult(ext, dirname)
 
         @test isapprox(result[1], sqrt.(df.x[1] .^ 2 + df.y[1] .^ 2))
+
+        ext = ExternalModel(
+            sourcedir,
+            sourcefile,
+            radius,
+            solver;
+            workdir=tempname(),
+            formats=numberformats,
+            extras="",
+        )
+        UncertaintyQuantification.makedirectory(ext, df[1, :], dirname)
+        @test isdir(dirname)
+        @test isfile(joinpath(dirname, "radius.jl"))
+        @test !isnotanywhere(joinpath(dirname, "radius.jl"), formatted_inputs[1])
+        @test !isnotanywhere(joinpath(dirname, "radius.jl"), formatted_inputs[2])
     end
 
     @testset "No Cleanup" begin


### PR DESCRIPTION
When an empty "extra" ```String``` is provided, both as standalone ```String``` or element of a ```Vector```, the ```makedirectory``` function will skip it.
closes #256