### PR TITLE
Add Nyquist frequency violation warning, and change naming of RVs in SRM method

### DIFF
--- a/src/inputs/stochasticprocesses/spectralrepresentation.jl
+++ b/src/inputs/stochasticprocesses/spectralrepresentation.jl
@@ -42,6 +42,15 @@ function SpectralRepresentation(
     psd::AbstractPowerSpectralDensity, time::AbstractVector{<:Real}, name::Symbol
 )
     Δω = psd.ω[2] - psd.ω[1]
+    ω_u = psd.ω[end] + Δω
+    Δt = time[2] - time[1]
+    f_max = ω_u/(2π)        # Frequency of the signal
+    f_s = 1/Δt              # Sampling Frequency
+    f_ny = f_s/2            # Nyquist Frequency
+
+    if f_max > f_ny
+        @warn "The frequency of the signal ($f_max Hz) is bigger than the Nyquist frequency ($f_ny Hz). There is a risk for aliasing!"
+    end
 
     A = sqrt.(2 * psd.p * Δω)
     A[iszero.(psd.ω)] .= 0.0
@@ -53,7 +62,7 @@ function SpectralRepresentation(
         Δω,
         A,
         name,
-        [Symbol("$(name)_$i") for i in 1:length(psd.ω)],
+        [Symbol("$(name)_ϕ_$i") for i in 1:length(psd.ω)],
     )
 end
 

--- a/test/inputs/stochasticprocesses/spectralrepresentation.jl
+++ b/test/inputs/stochasticprocesses/spectralrepresentation.jl
@@ -38,6 +38,9 @@
 
     @test ϕ ≈ ϕ_temp
 
+    t = collect(0:1:10)
+    @test_logs (:warn, r"The frequency of the signal") SpectralRepresentation(sd, t, :ShnzkNySR)
+
     @testset "Reliability" begin
         ω = collect(range(0, 150, 100))
 


### PR DESCRIPTION
Hi,

Mira and I implemented a Nyquist frequency violation warning inside the generation of the `spectralrepresentation` object. To warn the user that the time and frequency discretization may cause aliasing.

Additionally, Mira added the `varphi` to the naming of the RVs inside the `spectralrepresentation` method.

Here is how it looks like now:
<img width="2359" height="433" alt="image" src="https://github.com/user-attachments/assets/bbd65e3c-526b-433d-805a-ac88fbfbe61a" />

We also added a test that uses `test_logs` to check if the warning correctly appears.

These implementations and changes are referring to the Issue https://github.com/FriesischScott/UncertaintyQuantification.jl/issues/209 .
