### PR TITLE
Upgrade Documenter

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -9,6 +9,6 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 UncertaintyQuantification = "7183a548-a887-11e9-15ce-a56ab60bad7a"
 
 [compat]
-Documenter = "1.8.0"
-DocumenterCitations = "1.3.5"
-DocumenterVitepress = "0.1.6"
+Documenter = "1.14.1"
+DocumenterCitations = "1.4.1"
+DocumenterVitepress = "0.2.6"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -74,6 +74,10 @@ makedocs(;
     build="build",
 )
 
-deploydocs(;
-    repo="github.com/FriesischScott/UncertaintyQuantification.jl", push_preview=true
+DocumenterVitepress.deploydocs(;
+    repo="github.com/YourName/YourPackage.jl",
+    target=joinpath(@__DIR__, "build"),
+    branch="gh-pages",
+    devbranch="main", # or master, trunk, ...
+    push_preview=true,
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -75,9 +75,9 @@ makedocs(;
 )
 
 DocumenterVitepress.deploydocs(;
-    repo="github.com/YourName/YourPackage.jl",
+    repo="github.com/FriesischScott/UncertaintyQuantification.jl",
     target=joinpath(@__DIR__, "build"),
     branch="gh-pages",
-    devbranch="main", # or master, trunk, ...
+    devbranch="main",
     push_preview=true,
 )


### PR DESCRIPTION
Updates all dependencies to the latest version. This should also fix the 404 error on `stable`.