### PR TITLE
Test on lts and latest v1 release (stable)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       matrix:
         julia-version:
-          - "1.10"
-          - "1.11"
+          - "lts"
+          - "1"
         os:
           - "ubuntu-latest"
           - "windows-latest"


### PR DESCRIPTION
This way we don't have to update the workflow when a new minor version is released.