### PR TITLE
Different proposal for each dimension in SingleComponentMetropolisHastings

### DIFF
--- a/docs/src/manual/bayesianupdating.md
+++ b/docs/src/manual/bayesianupdating.md
@@ -89,7 +89,7 @@ logprior = df -> logpdf.(Beta(1,1), df.p)
 return nothing # hide
 ```
 
-**UncertaintyQuantification.jl** implements a variant of the MH algorithm known as single-component Metropolis-Hastings, where the proposal and acceptance step is performed independently for each dimension. To run the algorithm, we must first define the `SingleComponentMetropolisHastings` object which requires the `UnivariateDistribution` as a `proposal`, a `NamedTuple` for `x0` which defines the starting point of the Markov chain, the number of samples and the number of burn-in samples. The burn-in samples are used to start the chain but later discarded.
+**UncertaintyQuantification.jl** implements a variant of the MH algorithm known as single-component Metropolis-Hastings, where the proposal and acceptance step is performed independently for each dimension. To run the algorithm, we must first define the `SingleComponentMetropolisHastings` object which requires the `UnivariateDistribution` as a `proposal` (or a vector of proposal distributions), a `NamedTuple` for `x0` which defines the starting point of the Markov chain, the number of samples and the number of burn-in samples. The burn-in samples are used to start the chain but later discarded.
 
 ```@example metropolis
     proposal = Normal(0, 0.2)

--- a/src/modelupdating/bayesianupdating.jl
+++ b/src/modelupdating/bayesianupdating.jl
@@ -1,7 +1,7 @@
 """
     SingleComponentMetropolisHastings(proposal, x0, n, burnin, islog)
 
-Passed to [`bayesianupdating`](@ref) to run the single-component Metropolis-Hastings algorithm starting from `x0` with  univariate proposal distibution `proposal`. Will generate `n` samples *after* performing `burnin` steps of the Markov chain and discarding the samples. The flag `islog` specifies whether the prior and likelihood functions passed to the  [`bayesianupdating`](@ref) method are already  given as logarithms.
+Passed to [`bayesianupdating`](@ref) to run the single-component Metropolis-Hastings algorithm starting from `x0` with univariate proposal distibution `proposal` (or vector of proposal distributions per dimension). Will generate `n` samples *after* performing `burnin` steps of the Markov chain and discarding the samples. The flag `islog` specifies whether the prior and likelihood functions passed to the [`bayesianupdating`](@ref) method are already given as logarithms.
 
 Alternative constructor
 
@@ -11,14 +11,14 @@ Alternative constructor
 
 """
 struct SingleComponentMetropolisHastings <: AbstractBayesianMethod
-    proposal::UnivariateDistribution
+    proposal::Vector{<:UnivariateDistribution}
     x0::NamedTuple
     n::Int
     burnin::Int
     islog::Bool
 
     function SingleComponentMetropolisHastings(
-        proposal::UnivariateDistribution,
+        proposal::Union{UnivariateDistribution,Vector{<:UnivariateDistribution}},
         x0::NamedTuple,
         n::Int,
         burnin::Int,
@@ -26,6 +26,12 @@ struct SingleComponentMetropolisHastings <: AbstractBayesianMethod
     )
         if n <= 0
             error("Number of samples `n` must be positive")
+        end
+
+        if !isa(proposal, Vector)
+            proposal = fill(proposal, length(x0))
+        else
+            @assert length(x0) == length(proposal) "Number of proposal distribution must match the dimension."
         end
         return new(proposal, x0, n, burnin, islog)
     end
@@ -86,11 +92,11 @@ function bayesianupdating(
         x = DataFrame(samples[i, :])
 
         for d in 1:number_of_dimensions
-            x[1, d] += rand(mh.proposal)
+            x[1, d] += rand(mh.proposal[d])
 
             # safeguard for areas where the logprior is -Inf (prior = 0)
             while mh.islog ? isinf(prior(x)[1]) : isinf(log.(prior(x))[1])
-                x[1, d] = current[1, d] + rand(mh.proposal)
+                x[1, d] = current[1, d] + rand(mh.proposal[d])
             end
 
             if !isempty(models)

--- a/test/modelupdating/bayesianupdating.jl
+++ b/test/modelupdating/bayesianupdating.jl
@@ -238,12 +238,12 @@
     end
 
     @testset "Single Component MH bivariategaussian" begin
-        n = 50_000
-        burnin = 10_000
+        n = 100_000
+        burnin = 20_000
 
         x0 = (x=0.0, y=0.0)
 
-        proposal = Normal(0, 0.6)
+        proposal = Normal(0, 1)
 
         mh = SingleComponentMetropolisHastings(proposal, x0, n, burnin)
         mcmc_samples, analytic_mean, analytic_cov = bivariategaussian(mh, Uniform(-10, 10))

--- a/test/modelupdating/bayesianupdating.jl
+++ b/test/modelupdating/bayesianupdating.jl
@@ -144,6 +144,26 @@
         return mcmc_samples, mean(posterior_exact), std(posterior_exact)
     end
 
+    function bivariategaussian(sampler::AbstractBayesianMethod, prior::Uniform)
+        analytic_mean = [-0.5, 0.5]
+        analytic_cov = [1 0.8; 0.8 1]
+
+        function logprior(df)
+            return logpdf.(prior, df.x) .+ logpdf.(prior, df.y)
+        end
+
+        function loglikelihood(df)
+            return [
+                logpdf(MvNormal(analytic_mean, analytic_cov), collect(x)) for
+                x in eachrow(df)
+            ]
+        end
+
+        mcmc_samples, _ = bayesianupdating(logprior, loglikelihood, UQModel[], sampler)
+
+        return mcmc_samples, analytic_mean, analytic_cov
+    end
+
     @testset "Single Component MH binomal inference analytical" begin
         proposal = Normal()
         x0 = (x=0.5,)
@@ -213,8 +233,31 @@
         @test mh_vec.proposal[2] == proposal_vec[2]
 
         @test_throws AssertionError SingleComponentMetropolisHastings(
-            proposal_vec, (;x = 3.0), 1000, 100
+            proposal_vec, (; x=3.0), 1000, 100
         )
+    end
+
+    @testset "Single Component MH bivariategaussian" begin
+        n = 50_000
+        burnin = 10_000
+
+        x0 = (x=0.0, y=0.0)
+
+        proposal = Normal(0, 0.6)
+
+        mh = SingleComponentMetropolisHastings(proposal, x0, n, burnin)
+        mcmc_samples, analytic_mean, analytic_cov = bivariategaussian(mh, Uniform(-10, 10))
+
+        @test mean(mcmc_samples.x) ≈ analytic_mean[1] rtol = 0.1
+        @test mean(mcmc_samples.y) ≈ analytic_mean[2] rtol = 0.1
+
+        analytic_std_1 = sqrt(analytic_cov[1, 1])
+        analytic_std_2 = sqrt(analytic_cov[2, 2])
+        analytic_cor = analytic_cov[1, 2] / (analytic_std_1 * analytic_std_2)
+
+        @test std(mcmc_samples.x) ≈ analytic_std_1 rtol = 0.1
+        @test std(mcmc_samples.y) ≈ analytic_std_2 rtol = 0.1
+        @test cor(mcmc_samples.x, mcmc_samples.y) ≈ analytic_cor rtol = 0.1
     end
 
     @testset "TMCMC binomal inference analytical" begin
@@ -270,4 +313,27 @@
         @test mean(mc_samples.x) ≈ analytic_mean rtol = 0.1
         @test std(mc_samples.x) ≈ analytic_std rtol = 0.1
     end
+
+    @testset "TMCMC bivariategaussian" begin
+    n = 10_000
+    burnin = 5
+
+    prior_dist = Uniform(-10, 10)
+
+    prior = RandomVariable.(prior_dist, [:x, :y])
+
+    mh = TransitionalMarkovChainMonteCarlo(prior, n, burnin)
+    mcmc_samples, analytic_mean, analytic_cov = bivariategaussian(mh, prior_dist)
+
+    @test mean(mcmc_samples.x) ≈ analytic_mean[1] rtol = 0.1
+    @test mean(mcmc_samples.y) ≈ analytic_mean[2] rtol = 0.1
+
+    analytic_std_1 = sqrt(analytic_cov[1, 1])
+    analytic_std_2 = sqrt(analytic_cov[2, 2])
+    analytic_cor = analytic_cov[1, 2] / (analytic_std_1 * analytic_std_2)
+
+    @test std(mcmc_samples.x) ≈ analytic_std_1 rtol = 0.1
+    @test std(mcmc_samples.y) ≈ analytic_std_2 rtol = 0.1
+    @test cor(mcmc_samples.x, mcmc_samples.y) ≈ analytic_cor rtol = 0.1
+end
 end

--- a/test/modelupdating/bayesianupdating.jl
+++ b/test/modelupdating/bayesianupdating.jl
@@ -213,7 +213,7 @@
         @test mh_vec.proposal[2] == proposal_vec[2]
 
         @test_throws AssertionError SingleComponentMetropolisHastings(
-            proposal_vec, (x = 3.0), 1000, 100
+            proposal_vec, (;x = 3.0), 1000, 100
         )
     end
 

--- a/test/modelupdating/bayesianupdating.jl
+++ b/test/modelupdating/bayesianupdating.jl
@@ -198,6 +198,25 @@
         @test std(mc_samples.x) ≈ analytic_std rtol = 0.1
     end
 
+    @testset "Single Component MH proposal" begin
+        proposal = Normal()
+        x0 = (x=3.0, y=1.0)
+        mh = SingleComponentMetropolisHastings(proposal, x0, 1000, 100)
+
+        @test isa(mh.proposal, Vector{<:UnivariateDistribution})
+        @test mh.proposal[1] == proposal
+        @test mh.proposal[2] == proposal
+
+        proposal_vec = [Uniform(-1, 1), Normal(0, 0.1)]
+        mh_vec = SingleComponentMetropolisHastings(proposal_vec, x0, 1000, 100)
+        @test mh_vec.proposal[1] == proposal_vec[1]
+        @test mh_vec.proposal[2] == proposal_vec[2]
+
+        @test_throws AssertionError SingleComponentMetropolisHastings(
+            proposal_vec, (x = 3.0), 1000, 100
+        )
+    end
+
     @testset "TMCMC binomal inference analytical" begin
         n = 4000
         burnin = 100
@@ -251,5 +270,4 @@
         @test mean(mc_samples.x) ≈ analytic_mean rtol = 0.1
         @test std(mc_samples.x) ≈ analytic_std rtol = 0.1
     end
-    
 end


### PR DESCRIPTION
This PR adds the option to use multiple proposal distributions in `SingleComponentMetropolisHastings` which could be useful in some situations. The constructor now accepts `Union{UnivariateDistribution,Vector{<:UnivariateDistribution}}` as input for the `proposal`  and `bayesianupdating` can use different proposals for each dimension.