### PR TITLE
Add safeguard for failing cleanup step

### DIFF
--- a/src/models/external/externalmodel.jl
+++ b/src/models/external/externalmodel.jl
@@ -79,7 +79,11 @@ end
 function getresult(m::ExternalModel, path::String)
     result = map(e -> e.f(path), m.extractors)
     if m.cleanup
-        rm(path; recursive=true)
+        try
+            rm(path; recursive=true)
+        catch e
+            @warn "Error during cleanup: $e"
+        end
     end
     return result
 end


### PR DESCRIPTION
Since we have no idea why the cleanup sometimes tries to delete a non-existing folder we catch the error and log it so we might find out later.

Fixes #309.