### PR TITLE
Fix broken JointDistribution test

### DIFF
--- a/test/inputs/jointdistribution.jl
+++ b/test/inputs/jointdistribution.jl
@@ -147,12 +147,12 @@ copula = GaussianCopula([1 0.8; 0.8 1])
             @test names(jd) == [:x, :y]
 
             samples = sample(jd, 10^6)
-            @test_throws ErrorException(
-                "Cannot map ZeroMeanFullNormal{Tuple{Base.OneTo{Int64}}} to standard normal space.",
-            ) to_standard_normal_space!(jd, samples)
-            @test_throws ErrorException(
-                "Cannot map ZeroMeanFullNormal{Tuple{Base.OneTo{Int64}}} to physical space."
-            ) to_physical_space!(jd, samples)
+            @test_throws ["Cannot map", "to standard normal space."] to_standard_normal_space!(
+                jd, samples
+            )
+            @test_throws ["Cannot map", "to physical space."] to_physical_space!(
+                jd, samples
+            )
         end
     end
 end


### PR DESCRIPTION
Distributions dropped some aliases for the `MVNormal` that we were using in the tests. I'm now testing a few subexpressions of the exception which should be robust going forward.