### PR TITLE
Restore isimprecise for vector of inputs

### DIFF
--- a/docs/src/api/inputs.md
+++ b/docs/src/api/inputs.md
@@ -24,4 +24,6 @@ JointDistribution
 sample(rv::RandomVariable, n::Integer=1)
 sample(inputs::Vector{<:UQInput}, n::Integer=1)
 GaussianMixtureModel
+isimprecise(i::UQInput)
+isimprecise(inputs::AbstractVector{<:UQInput})
 ```

--- a/docs/src/api/models.md
+++ b/docs/src/api/models.md
@@ -21,4 +21,7 @@ LinearBasisFunctionModel
 evaluate!(m::Model, df::DataFrame)
 evaluate!(m::ParallelModel, df::DataFrame)
 reliability(ipm::IntervalPredictorModel, ϵ::Real)
+isimprecise(i::UQModel)
+isimprecise(inputs::AbstractVector{<:UQModel})
+isimprecise(inputs::AbstractVector{<:UQInput},models::AbstractVector{<:UQModel})
 ```

--- a/src/UncertaintyQuantification.jl
+++ b/src/UncertaintyQuantification.jl
@@ -208,7 +208,6 @@ export variancediagnostic
 include("util/binning.jl")
 include("util/fourier-transform.jl")
 include("util/wrap.jl")
-include("util/imprecise.jl")
 include("util/kde.jl")
 
 include("inputs/empiricaldistribution.jl")
@@ -266,4 +265,5 @@ include("reliability/probabilityoffailure.jl")
 include("reliability/probabilityoffailure_imprecise.jl")
 include("sensitivity/sobolindices.jl")
 
+include("util/imprecise.jl")
 end

--- a/src/UncertaintyQuantification.jl
+++ b/src/UncertaintyQuantification.jl
@@ -182,6 +182,7 @@ export evaluate
 export evaluate!
 export gradient
 export gradient_in_standard_normal_space
+export isimprecise
 export linear_binning
 export logpdf
 export mapfromdensity

--- a/src/models/ipm.jl
+++ b/src/models/ipm.jl
@@ -86,8 +86,6 @@ function reliability(ipm::IntervalPredictorModel, ϵ::Real)
     return cdf(Binomial(ipm.N, ϵ), 2 * length(ipm.b) - 1)
 end
 
-isimprecise(ipm::IntervalPredictorModel) = true
-
 function bounds(ipm::IntervalPredictorModel)
     return min.(ipm.p_lb, ipm.p_ub), max.(ipm.p_lb, ipm.p_ub)
 end

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -1,5 +1,3 @@
-isimprecise(m::UQModel) = false
-
 name(m::UQModel) = m.name
 
 names(models::AbstractVector{<:UQModel}) = UncertaintyQuantification.name.(models)

--- a/src/util/imprecise.jl
+++ b/src/util/imprecise.jl
@@ -1,13 +1,25 @@
+isimprecise(_::UQInput) = false
+
+isimprecise(rv::RandomVariable{<:ProbabilityBox}) = true
+
+isimprecise(i::IntervalVariable) = true
+
+function isimprecise(jd::JointDistribution{<:Copulas.Copula,<:RandomVariable})
+    return any(isimprecise.(jd.m))
+end
+
+isimprecise(_::UQModel) = false
+
+isimprecise(ipm::IntervalPredictorModel) = true
+
 function isimprecise(inputs::AbstractVector{<:UQInput}, models::AbstractVector{<:UQModel})
-    return any(isimprecise.(inputs)) || any(isimprecise.(models))
+    return isimprecise(inputs) || isimprecise(models)
 end
 
-function isimprecise(input::UQInput)
-    return isa(input, IntervalVariable) ||
-           isa(input, RandomVariable{<:ProbabilityBox}) ||
-           (
-               isa(input, JointDistribution{<:Copulas.Copula,<:RandomVariable}) &&
-               any(isa.(input.m, RandomVariable{<:ProbabilityBox}))
-           )
+function isimprecise(inputs::AbstractVector{<:UQInput})
+    return any(isimprecise.(inputs))
 end
 
+function isimprecise(models::AbstractVector{<:UQModel})
+    return any(isimprecise.(models))
+end

--- a/src/util/imprecise.jl
+++ b/src/util/imprecise.jl
@@ -1,3 +1,8 @@
+"""
+    isimprecise(i::UQInput)
+
+Returns `true` if input `i` is imprecise.
+"""
 isimprecise(_::UQInput) = false
 
 isimprecise(rv::RandomVariable{<:ProbabilityBox}) = true
@@ -8,18 +13,37 @@ function isimprecise(jd::JointDistribution{<:Copulas.Copula,<:RandomVariable})
     return any(isimprecise.(jd.m))
 end
 
+"""
+    isimprecise(m::UQModel)
+
+Returns `true` if model `m` is imprecise.
+"""
 isimprecise(_::UQModel) = false
 
 isimprecise(ipm::IntervalPredictorModel) = true
 
+"""
+    isimprecise(inputs::AbstractVector{<:UQInput},models::AbstractVector{<:UQModel})
+
+Returns `true` if any of the `inputs` or `models` is imprecise.
+"""
 function isimprecise(inputs::AbstractVector{<:UQInput}, models::AbstractVector{<:UQModel})
     return isimprecise(inputs) || isimprecise(models)
 end
 
+"""
+    isimprecise(inputs::AbstractVector{<:UQInput})
+    
+Returns `true` if any of the `inputs` is imprecise.
+"""
 function isimprecise(inputs::AbstractVector{<:UQInput})
     return any(isimprecise.(inputs))
 end
+"""
+    isimprecise(models::AbstractVector{<:UQModel})
 
+Returns `true` if any of the `models` is imprecise.
+"""
 function isimprecise(models::AbstractVector{<:UQModel})
     return any(isimprecise.(models))
 end


### PR DESCRIPTION
I'm also exporting the function and added docstrings.

Closes #330.